### PR TITLE
bump version to 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set ( ROCDXG "rocdxg" )
 set ( ROCDXG_PACKAGE "rocdxg-roct" )
 set ( ROCDXG_COMPONENT "lib${ROCDXG}" )
 set ( ROCDXG_TARGET "${ROCDXG}" )
-set ( ROCDXG_VERSION "1.1.0")
+set ( ROCDXG_VERSION "1.1.1")
 
 project ( ${ROCDXG_TARGET} VERSION ${ROCDXG_VERSION} )
 # Project/version initialized; expose version to code via target defs below


### PR DESCRIPTION
- implement new thunk API introduced in rocm 7.12
- check scratch memory size overflow