### PR TITLE
dxg/wsl: fix div-by-zero in topology; skip non-queryable adapters

### DIFF
--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -528,14 +528,16 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id,
   props.FComputeIdLo = 0;
   props.Capability.ui32.ASICRevision = device->AsicRevision();
   props.Capability.ui32.WatchPointsTotalBits =
-      std::log2(device->WatchPointsNum());
-  props.MaxWavesPerSIMD = device->WavePerCu() / device->SimdPerCu();
+      device->WatchPointsNum() ? std::log2(device->WatchPointsNum()) : 0;
+  props.MaxWavesPerSIMD =
+      device->SimdPerCu() ? device->WavePerCu() / device->SimdPerCu() : 0;
   props.LDSSizeInKB = device->LdsSize() / 1024;
   props.GDSSizeInKB = 0;
   props.WaveFrontSize = device->WavefrontSize();
   props.NumShaderBanks = device->NumShaderEngine();
   props.NumArrays = device->ShaderArrayPerShaderEngine();
-  props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
+  props.NumCUPerArray = props.NumArrays
+                          ? device->ComputeUnitCount() / props.NumArrays : 0;
   props.NumSIMDPerCU = device->SimdPerCu();
   props.MaxSlotsScratchCU = device->MaxScratchSlotsPerCu();
   props.VendorId = 0x1002;
@@ -592,6 +594,18 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id,
   props.EngineId.ui32.Minor = device->Minor();
   props.EngineId.ui32.Stepping = device->Stepping();
 
+  /* GFX version should already be populated by ParseDeviceInfo() via
+   * HSA_OVERRIDE_GFX_VERSION or device-specific detection.  Fall back to
+   * the topology-level override as a last resort; log an error if still 0. */
+  if (!props.EngineId.ui32.Major) {
+    if (props.OverrideEngineId.ui32.Major) {
+      props.EngineId = props.OverrideEngineId;
+      pr_warn("GFX version from HSA_OVERRIDE_GFX_VERSION\n");
+    } else {
+      pr_err("GFX version is 0 — set HSA_OVERRIDE_GFX_VERSION\n");
+    }
+  }
+
   snprintf((char *)props.AMDName, sizeof(props.AMDName) - 1, "GFX%06x",
            HSA_GET_GFX_VERSION_FULL(props.EngineId.ui32));
 
@@ -603,9 +617,8 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id,
   props.SGPRSizePerCU = SGPR_SIZE_PER_CU;
   props.VGPRSizePerCU = get_vgpr_size_per_cu(props.EngineId);
 
-  if (props.NumFComputeCores)
-    assert(props.EngineId.ui32.Major &&
-           "HSA_OVERRIDE_GFX_VERSION may be needed");
+  if (props.NumFComputeCores && !props.EngineId.ui32.Major)
+    pr_err("GFX version still unknown - set HSA_OVERRIDE_GFX_VERSION\n");
 
   return ret;
 }

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -549,8 +549,10 @@ NTSTATUS WDDMCreateDevices(std::vector<WDDMDevice *> &devices)
 
     ret = WDDMQueryAdapter(info[i].hAdapter, KMTQAITYPE_PHYSICALADAPTERDEVICEIDS,
 			   &query, sizeof(query));
-    if (ret != STATUS_SUCCESS)
-      goto err_out1;
+    if (ret != STATUS_SUCCESS) {
+      pr_debug("adapter %d query failed (0x%x), skipping\n", i, ret);
+      continue; /* non-fatal: skip adapters that cannot be queried */
+    }
 
     if (query.DeviceIds.VendorID != 0x1002)
       continue;


### PR DESCRIPTION
# dxg/wsl: fix div-by-zero in topology; skip non-queryable adapters

## Motivation

Two generic robustness issues in librocdxg can cause crashes or silent
failures on any supported device:

1. Integer divisions and a `std::log2` call in `topology.cpp` are performed
   without guarding against zero denominators, triggering undefined behaviour
   for devices with partially populated `DeviceInfo`.
2. A `WDDMQueryAdapter` failure for one adapter aborts the entire device
   enumeration loop, silently preventing any GPU from being found on systems
   where a non-queryable adapter (e.g. a software renderer) appears before
   the compute GPU.

## Technical Details

### `src/topology.cpp`

- Guard `WatchPointsNum()` against zero before passing to `std::log2`.
- Guard `SimdPerCu()` against zero before computing `MaxWavesPerSIMD`.
- Guard `NumArrays` against zero before computing `NumCUPerArray`.
- Replace `assert(EngineId.Major && "…")` with `pr_err`. Release builds
  must not abort on this condition; the diagnostic needs to reach the user.
- When `EngineId.Major` remains 0 after `ParseDeviceInfo`, apply
  `OverrideEngineId` (from `HSA_OVERRIDE_GFX_VERSION`) and log a warning;
  log an error if both are unset.

All guards produce identical results for devices that already report
non-zero values — only the zero case is changed.

### `src/wddm/device.cpp` — `WDDMCreateDevices`

Changed `goto err_out1` to `continue` with a `pr_debug` message so a
single non-queryable adapter does not abort the entire enumeration.
The `QueryAdapterSupported` allowlist is unchanged and remains the gate
for device enumeration.

## JIRA ID

N/A

## Test Plan

Built librocdxg on WSL2 Ubuntu 24.04 with the standard cmake build. The
div-by-zero guards were validated to produce identical output to the
original code for all non-zero inputs.

## Test Result

Build succeeds with no warnings introduced by these changes. The guarded
expressions return the same values as before for any device that reports
non-zero fields.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
