### PR TITLE
wsl/librocdxg: Add abi size check

### DIFF
--- a/include/hsakmt/hsakmttypes.h
+++ b/include/hsakmt/hsakmttypes.h
@@ -1565,6 +1565,12 @@ typedef struct _HsaHandleImportFlags {
     } ui32;
 } HsaHandleImportFlags;
 
+typedef struct _HsaStructureSizes {
+  HSAuint16 StructureSizes;           // sizeof(HsaStructureSizes) used for check overflow
+  HSAuint16 SizeOfHsaNodeProperties;  // sizeof(HsaNodeProperties)
+  HSAuint16 Reserved[6];
+} HsaStructureSizes;
+
 #ifdef __cplusplus
 }   //extern "C"
 #endif

--- a/src/librocdxg.h
+++ b/src/librocdxg.h
@@ -68,7 +68,8 @@ struct hsakmtRuntime {
     system_heap_space_size_(0),
     handle_aperture_start_(0),
     handle_aperture_size_(0),
-    default_node(1) {}
+    default_node(1),
+    detected_abi_({}) {}
 
   void HeapInit();
   void HeapFini();
@@ -134,6 +135,8 @@ struct hsakmtRuntime {
   uint64_t handle_aperture_start_;
   uint64_t handle_aperture_size_;
   std::unique_ptr<wsl::thunk::VaMgr> handle_aperture_mgr_;
+
+  HsaStructureSizes detected_abi_;
 };
 
 extern hsakmtRuntime *dxg_runtime;
@@ -304,5 +307,13 @@ int amdgpu_bo_va_op_impl(amdgpu_bo_handle bo,
                               uint64_t addr,
                               uint64_t flags,
                               uint32_t ops);
+
+
+// ---------------------------------------------------------------------------
+// ROCr ABI capability detection
+// ---------------------------------------------------------------------------
+extern "C" HSAKMT_STATUS HSAKMTAPI DxgAbiCheck(
+  HsaStructureSizes *actual  // IN
+);
 
 #endif

--- a/src/librocdxg.ver
+++ b/src/librocdxg.ver
@@ -102,6 +102,7 @@ hsaKmtMemoryVaUnmap;
 hsaKmtMemHandleFree;
 hsaKmtMemoryGetCpuAddr;
 hsaKmtMemoryCpuMap;
+DxgAbiCheck;
 amdgpu_device_initialize;
 amdgpu_device_deinitialize;
 amdgpu_query_gpu_info;

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -1220,7 +1220,24 @@ HSAKMT_STATUS topology_get_node_props(HSAuint32 NodeId,
   if (!dxg_topology->g_system || dxg_topology->g_props.empty() || NodeId >= dxg_topology->g_system->NumNodes)
     return HSAKMT_STATUS_ERROR;
 
-  *NodeProperties = dxg_topology->g_props[NodeId].node;
+  // Copy only as many bytes as ROCr's HsaNodeProperties buffer can hold.
+  // If DxgAbiCheck has not run yet (rocr_node_props_size == 0) we fall back
+  // to a full struct copy (old behaviour, same as before this change).
+  //
+  // - ROCr older than us  → rocr_node_props_size < sizeof(HsaNodeProperties)
+  //   Only the base fields are written; new fields (WallClockKHz etc.) are
+  //   not touched, avoiding a buffer overrun.
+  //
+  // - ROCr same / newer   → rocr_node_props_size >= sizeof(HsaNodeProperties)
+  //   All fields including the extended ones are filled in.
+  size_t copySize;
+  if (dxg_runtime->detected_abi_.SizeOfHsaNodeProperties > 0)
+    copySize = std::min((size_t)dxg_runtime->detected_abi_.SizeOfHsaNodeProperties,
+                        sizeof(HsaNodeProperties));
+  else
+    copySize = 368;
+
+  memcpy(NodeProperties, &dxg_topology->g_props[NodeId].node, copySize);
   return HSAKMT_STATUS_SUCCESS;
 }
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -34,3 +34,27 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetVersion(HsaVersionInfo *VersionInfo) {
 
   return HSAKMT_STATUS_SUCCESS;
 }
+
+HSAKMT_STATUS HSAKMTAPI DxgAbiCheck(HsaStructureSizes *actual)
+{
+  if (actual == nullptr)
+  {
+    fprintf(stderr, "[ROCr/DXG] DxgAbiCheck: received nullptr.\n");
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+  }
+
+  if (actual->StructureSizes != sizeof(HsaStructureSizes)) {
+    bool is_larger = actual->StructureSizes > sizeof(HsaStructureSizes);
+    fprintf(stderr,
+            "[ROCr/DXG] DxgAbiCheck: StructureSizes=%u is too %s (expected %zu). Please update your "
+            "%s version.\n",
+            actual->StructureSizes, is_larger ? "large" : "small", sizeof(HsaStructureSizes),
+            is_larger ? "librocdxg" : "ROCr");
+
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+  }
+
+  dxg_runtime->detected_abi_ = *actual;
+
+  return HSAKMT_STATUS_SUCCESS;
+}


### PR DESCRIPTION
Reviewed-by: lyndonli <Lyndon.Li@amd.com>
Reviewed-by: Flora Cui <flora.cui@amd.com>

wsl/librocdxg: Hardcode copySize of HsaNodeProperties

Use the current size before CheckThunkAbi takes effect in the ROCm system to prevent structure assignment overrides caused by size changes.

Reviewed-by: Flora Cui <flora.cui@amd.com>
