### PR TITLE
wsl adapter fallback clean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set ( ROCDXG_SRC "src/debug.cpp"
                  "src/hsakmtmodel.cpp"
                  "src/dxcore_loader.cpp"
                  "src/ais.cpp"
+                 "src/wddm/adapter_policy.cpp"
                  "src/wddm/device.cpp"
                  "src/wddm/gpu_memory.cpp"
                  "src/wddm/va_mgr.cpp"
@@ -137,8 +138,9 @@ target_include_directories( ${ROCDXG_TARGET}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-  ${WIN_SDK}
   ${CMAKE_CURRENT_SOURCE_DIR}/src )
+
+target_include_directories(${ROCDXG_TARGET} SYSTEM PRIVATE ${WIN_SDK})
 
 add_compile_definitions(LINUX __AMD64__ LITTLEENDIAN_CPU HSA_LARGE_MODEL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ list( PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules" )
 ## Include common cmake modules
 include ( utils )
 include ( GNUInstallDirs )
+include ( CTest )
 
 ## Setup the package version.
 get_version ( "${ROCDXG_VERSION}" )
@@ -315,3 +316,7 @@ cpack_add_component(binary
 cpack_add_component(dev
   DISPLAY_NAME "Development"
   DESCRIPTION "ROCDXG development files (pkgconfig and cmake)")
+
+if (BUILD_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -23,17 +23,192 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include <cstdio>
-#include <cassert>
-#include <thread>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace {
+
+std::atomic<HSA_EVENTID> g_next_event_id{1};
+
+class EventState {
+public:
+  EventState(bool manual_reset, bool signaled)
+      : signaled_(signaled), manual_reset_(manual_reset) {}
+
+  void Set() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      signaled_ = true;
+    }
+    if (manual_reset_)
+      condition_.notify_all();
+    else
+      condition_.notify_one();
+  }
+
+  void Reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    signaled_ = false;
+  }
+
+  void ConsumeIfAutoReset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!manual_reset_ && signaled_)
+      signaled_ = false;
+  }
+
+  bool IsSignaled() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return signaled_;
+  }
+
+  HSAKMT_STATUS Wait(HSAuint32 milliseconds) {
+    return WaitInternal(milliseconds, true);
+  }
+
+  HSAKMT_STATUS WaitUntilSignaled(HSAuint32 milliseconds) {
+    return WaitInternal(milliseconds, false);
+  }
+
+private:
+  HSAKMT_STATUS WaitInternal(HSAuint32 milliseconds, bool consume) {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    if (!signaled_) {
+      if (milliseconds == HSA_EVENTTIMEOUT_INFINITE) {
+        condition_.wait(lock, [this] { return signaled_; });
+      } else if (!condition_.wait_for(lock, std::chrono::milliseconds(milliseconds),
+                                      [this] { return signaled_; })) {
+        return HSAKMT_STATUS_WAIT_TIMEOUT;
+      }
+    }
+
+    if (consume && !manual_reset_)
+      signaled_ = false;
+
+    return HSAKMT_STATUS_SUCCESS;
+  }
+
+  mutable std::mutex mutex_;
+  std::condition_variable condition_;
+  bool signaled_;
+  bool manual_reset_;
+};
+
+bool IsSupportedEventType(HSA_EVENTTYPE event_type) {
+  return event_type == HSA_EVENTTYPE_SIGNAL;
+}
+
+EventState *GetEventState(HsaEvent *event) {
+  return reinterpret_cast<EventState *>(event->EventData.HWData1);
+}
+
+void SetSignaled(HsaEvent *event, bool signaled) {
+  event->EventData.HWData3 = signaled ? 1 : 0;
+}
+
+HSAKMT_STATUS WaitOnMultipleEvents(EventState *states[], HSAuint32 num_events,
+                                   bool wait_on_all, HSAuint32 milliseconds,
+                                   uint64_t *event_age) {
+  if (!states || !num_events)
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (event_age)
+    *event_age = 0;
+
+  auto remaining_ms = milliseconds;
+  auto start = std::chrono::steady_clock::now();
+  const bool infinite = milliseconds == HSA_EVENTTIMEOUT_INFINITE;
+
+  if (wait_on_all) {
+    for (HSAuint32 i = 0; i < num_events; i++) {
+      if (!states[i])
+        return HSAKMT_STATUS_INVALID_HANDLE;
+
+      auto status =
+          states[i]->WaitUntilSignaled(infinite ? HSA_EVENTTIMEOUT_INFINITE
+                                                : remaining_ms);
+      if (status != HSAKMT_STATUS_SUCCESS)
+        return status;
+
+      if (!infinite) {
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed_ms = static_cast<HSAuint32>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - start)
+                .count());
+        remaining_ms =
+            elapsed_ms >= milliseconds ? 0 : milliseconds - elapsed_ms;
+      }
+    }
+
+    for (HSAuint32 i = 0; i < num_events; i++)
+      states[i]->ConsumeIfAutoReset();
+
+    return HSAKMT_STATUS_SUCCESS;
+  }
+
+  while (true) {
+    for (HSAuint32 i = 0; i < num_events; i++) {
+      if (!states[i])
+        return HSAKMT_STATUS_INVALID_HANDLE;
+
+      auto status = states[i]->Wait(0);
+      if (status == HSAKMT_STATUS_SUCCESS)
+        return status;
+      if (status != HSAKMT_STATUS_WAIT_TIMEOUT)
+        return status;
+    }
+
+    if (!infinite) {
+      auto now = std::chrono::steady_clock::now();
+      auto elapsed_ms = static_cast<HSAuint32>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(now - start)
+              .count());
+      if (elapsed_ms >= milliseconds)
+        return HSAKMT_STATUS_WAIT_TIMEOUT;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+} // namespace
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtCreateEvent(HsaEventDescriptor *EventDesc,
                                           bool ManualReset, bool IsSignaled,
                                           HsaEvent **Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
-  assert(false);
+
+  if (!EventDesc || !Event)
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (!IsSupportedEventType(EventDesc->EventType))
+    return HSAKMT_STATUS_NOT_SUPPORTED;
+
+  auto *event = reinterpret_cast<HsaEvent *>(calloc(1, sizeof(HsaEvent)));
+  if (!event)
+    return HSAKMT_STATUS_NO_MEMORY;
+
+  auto *state = new EventState(ManualReset, IsSignaled);
+  if (!state) {
+    free(event);
+    return HSAKMT_STATUS_NO_MEMORY;
+  }
+
+  event->EventId = g_next_event_id.fetch_add(1, std::memory_order_relaxed);
+  event->EventData.EventType = EventDesc->EventType;
+  event->EventData.EventData.SyncVar = EventDesc->SyncVar;
+  event->EventData.HWData1 = reinterpret_cast<HSAuint64>(state);
+  event->EventData.HWData2 = ManualReset ? 1 : 0;
+  SetSignaled(event, IsSignaled);
+
+  *Event = event;
   return HSAKMT_STATUS_SUCCESS;
 }
 
@@ -42,38 +217,50 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyEvent(HsaEvent *Event) {
   if (!Event)
     return HSAKMT_STATUS_SUCCESS;
 
-  pr_warn_once("not supported\n");
-  assert(false);
+  delete GetEventState(Event);
+
+  free(Event);
   return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtSetEvent(HsaEvent *Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
   if (!Event)
     return HSAKMT_STATUS_INVALID_HANDLE;
 
-  assert(false);
+  auto *state = GetEventState(Event);
+  if (!state)
+    return HSAKMT_STATUS_INVALID_HANDLE;
+
+  state->Set();
+  SetSignaled(Event, true);
   return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtResetEvent(HsaEvent *Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
   if (!Event)
     return HSAKMT_STATUS_INVALID_HANDLE;
 
-  assert(false);
+  auto *state = GetEventState(Event);
+  if (!state)
+    return HSAKMT_STATUS_INVALID_HANDLE;
+
+  state->Reset();
+  SetSignaled(Event, state->IsSignaled());
   return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtQueryEventState(HsaEvent *Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
   if (!Event)
     return HSAKMT_STATUS_INVALID_HANDLE;
 
-  assert(false);
+  auto *state = GetEventState(Event);
+  if (!state)
+    return HSAKMT_STATUS_INVALID_HANDLE;
+
+  SetSignaled(Event, state->IsSignaled());
   return HSAKMT_STATUS_SUCCESS;
 }
 
@@ -107,16 +294,32 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtWaitOnMultipleEvents_Ext(HsaEvent *Events[],
                                                        uint64_t *event_age) {
   CHECK_DXG_OPEN();
 
-  if (!Events)
-    return HSAKMT_STATUS_INVALID_HANDLE;
+  if (!Events || !NumEvents)
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (event_age)
+    *event_age = 0;
 
   if (NumEvents == 1 && Events[0] == nullptr) {
     std::this_thread::sleep_for(std::chrono::microseconds(20));
     return HSAKMT_STATUS_SUCCESS;
   }
 
-  assert(false);
-  return HSAKMT_STATUS_SUCCESS;
+  std::vector<EventState *> states(NumEvents);
+  for (HSAuint32 i = 0; i < NumEvents; i++) {
+    if (!Events[i] || !GetEventState(Events[i]))
+      return HSAKMT_STATUS_INVALID_HANDLE;
+    states[i] = GetEventState(Events[i]);
+  }
+
+  auto status = WaitOnMultipleEvents(states.data(), NumEvents, WaitOnAll,
+                                     Milliseconds, event_age);
+  if (status == HSAKMT_STATUS_SUCCESS) {
+    for (HSAuint32 i = 0; i < NumEvents; i++)
+      SetSignaled(Events[i], states[i]->IsSignaled());
+  }
+
+  return status;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSMI(HSAuint32 NodeId, int *fd) {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -127,6 +127,9 @@ HSAKMT_STATUS WaitOnMultipleEvents(EventState *states[], HSAuint32 num_events,
   const bool infinite = milliseconds == HSA_EVENTTIMEOUT_INFINITE;
 
   if (wait_on_all) {
+    // Delay auto-reset consumption until every event has been observed so a
+    // timed out aggregate wait does not clear a signal that another waiter
+    // still needs to see.
     for (HSAuint32 i = 0; i < num_events; i++) {
       if (!states[i])
         return HSAKMT_STATUS_INVALID_HANDLE;

--- a/src/wddm/adapter_policy.cpp
+++ b/src/wddm/adapter_policy.cpp
@@ -69,6 +69,8 @@ bool ApplyAdapterInfoFallback(thunk_proxy::DeviceInfo &device_info) {
   if (!fallback)
     return false;
 
+  // Only backfill fields that the adapter query left unset so parsed metadata
+  // remains authoritative whenever the runtime already supplied it.
   bool used_fallback = false;
 
   if (device_info.major == 0) {

--- a/src/wddm/adapter_policy.cpp
+++ b/src/wddm/adapter_policy.cpp
@@ -1,0 +1,95 @@
+#include <cstdio>
+#include <strings.h>
+
+#include "wddm/adapter_policy.h"
+
+namespace wsl {
+namespace thunk {
+namespace adapter_policy {
+
+const AdapterInfoFallback *FindAdapterInfoFallback(uint32_t device_id) {
+  static const AdapterInfoFallback kFallbacks[] = {
+      {0x73E3, 10, 3, 2, 28},
+      {0x73EF, 10, 3, 2, 28},
+  };
+
+  for (const auto &fallback : kFallbacks) {
+    if (fallback.device_id == device_id)
+      return &fallback;
+  }
+
+  return nullptr;
+}
+
+bool HasValidGfxOverrideValue(const char *value) {
+  if (!value || !value[0])
+    return false;
+
+  char dummy = '\0';
+  uint32_t major = 0, minor = 0, step = 0;
+  return (std::sscanf(value, "%u.%u.%u%c", &major, &minor, &step, &dummy) ==
+          3) &&
+         (major <= 63 && minor <= 255 && step <= 255);
+}
+
+bool IsEnabledValue(const char *value) {
+  if (!value || !value[0])
+    return false;
+
+  return !strcasecmp(value, "1") || !strcasecmp(value, "true") ||
+         !strcasecmp(value, "yes") || !strcasecmp(value, "on");
+}
+
+bool ShouldAllowUnsupportedAdapter(uint32_t vendor_id, uint32_t device_id,
+                                   bool has_gfx_override,
+                                   bool enable_unsupported_adapters) {
+  if (vendor_id != 0x1002)
+    return false;
+
+  if (FindAdapterInfoFallback(device_id) == nullptr)
+    return false;
+
+  if (enable_unsupported_adapters)
+    return true;
+
+  return has_gfx_override;
+}
+
+const char *UnsupportedAdapterReason(uint32_t device_id, bool has_gfx_override,
+                                     bool enable_unsupported_adapters) {
+  if (has_gfx_override && FindAdapterInfoFallback(device_id) != nullptr)
+    return "HSA_OVERRIDE_GFX_VERSION";
+  if (enable_unsupported_adapters)
+    return "LIBROCDXG_ENABLE_UNSUPPORTED_ADAPTERS";
+  return nullptr;
+}
+
+bool ApplyAdapterInfoFallback(thunk_proxy::DeviceInfo &device_info) {
+  const auto *fallback = FindAdapterInfoFallback(device_info.device_id);
+  if (!fallback)
+    return false;
+
+  bool used_fallback = false;
+
+  if (device_info.major == 0) {
+    device_info.major = fallback->major;
+    used_fallback = true;
+  }
+  if (device_info.minor == 0) {
+    device_info.minor = fallback->minor;
+    used_fallback = true;
+  }
+  if (device_info.stepping == 0) {
+    device_info.stepping = fallback->stepping;
+    used_fallback = true;
+  }
+  if (device_info.compute_unit_count == 0) {
+    device_info.compute_unit_count = fallback->compute_unit_count;
+    used_fallback = true;
+  }
+  return used_fallback;
+}
+
+} // namespace adapter_policy
+} // namespace thunk
+} // namespace wsl

--- a/src/wddm/adapter_policy.cpp
+++ b/src/wddm/adapter_policy.cpp
@@ -7,13 +7,21 @@ namespace wsl {
 namespace thunk {
 namespace adapter_policy {
 
-const AdapterInfoFallback *FindAdapterInfoFallback(uint32_t device_id) {
-  static const AdapterInfoFallback kFallbacks[] = {
-      {0x73E3, 10, 3, 2, 28},
-      {0x73EF, 10, 3, 2, 28},
-  };
+namespace {
 
-  for (const auto &fallback : kFallbacks) {
+// Known WSL adapter parse gaps. These defaults only backfill zero-valued
+// metadata returned by ParseAdapterInfo for adapters that the user explicitly
+// opted into. The override target remains user-controlled through
+// HSA_OVERRIDE_GFX_VERSION.
+constexpr AdapterInfoFallback kKnownAdapterInfoFallbacks[] = {
+    {0x73E3, 10, 3, 2, 28},
+    {0x73EF, 10, 3, 2, 28},
+};
+
+} // namespace
+
+const AdapterInfoFallback *FindAdapterInfoFallback(uint32_t device_id) {
+  for (const auto &fallback : kKnownAdapterInfoFallbacks) {
     if (fallback.device_id == device_id)
       return &fallback;
   }
@@ -46,6 +54,8 @@ bool ShouldAllowUnsupportedAdapter(uint32_t vendor_id, uint32_t device_id,
   if (vendor_id != 0x1002)
     return false;
 
+  // Keep explicit opt-in scoped to adapters with known metadata gaps instead
+  // of admitting arbitrary unsupported devices into enumeration.
   if (FindAdapterInfoFallback(device_id) == nullptr)
     return false;
 

--- a/src/wddm/adapter_policy.h
+++ b/src/wddm/adapter_policy.h
@@ -1,0 +1,37 @@
+#ifndef LIBROCDXG_WDDM_ADAPTER_POLICY_H
+#define LIBROCDXG_WDDM_ADAPTER_POLICY_H
+
+#include "librocdxg.h"
+
+namespace wsl {
+namespace thunk {
+namespace adapter_policy {
+
+struct AdapterInfoFallback {
+  uint32_t device_id;
+  int major;
+  int minor;
+  int stepping;
+  uint32_t compute_unit_count;
+};
+
+const AdapterInfoFallback *FindAdapterInfoFallback(uint32_t device_id);
+
+bool HasValidGfxOverrideValue(const char *value);
+
+bool IsEnabledValue(const char *value);
+
+bool ShouldAllowUnsupportedAdapter(uint32_t vendor_id, uint32_t device_id,
+                                   bool has_gfx_override,
+                                   bool enable_unsupported_adapters);
+
+const char *UnsupportedAdapterReason(uint32_t device_id, bool has_gfx_override,
+                                     bool enable_unsupported_adapters);
+
+bool ApplyAdapterInfoFallback(thunk_proxy::DeviceInfo &device_info);
+
+} // namespace adapter_policy
+} // namespace thunk
+} // namespace wsl
+
+#endif

--- a/src/wddm/adapter_policy.h
+++ b/src/wddm/adapter_policy.h
@@ -1,7 +1,10 @@
 #ifndef LIBROCDXG_WDDM_ADAPTER_POLICY_H
 #define LIBROCDXG_WDDM_ADAPTER_POLICY_H
 
-#include "librocdxg.h"
+#include <cstdint>
+
+#include "impl/wddm/types.h"
+#include "impl/thunk_proxy/thunk_proxy.h"
 
 namespace wsl {
 namespace thunk {

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -42,6 +42,8 @@
 
 #include <cinttypes>
 #include <bitset>
+#include <cstdlib>
+#include <cstring>
 
 #include <sys/mman.h>
 #include <sys/sysinfo.h>
@@ -53,6 +55,7 @@
 #include "impl/wddm/types.h"
 #include "impl/wddm/device.h"
 #include "impl/wddm/queue.h"
+#include "wddm/adapter_policy.h"
 
 namespace wsl {
 namespace thunk {
@@ -524,6 +527,12 @@ uint32_t WDDMDevice::LdsBlocks(const hsa_kernel_dispatch_packet_t *pkt) {
 NTSTATUS WDDMCreateDevices(std::vector<WDDMDevice *> &devices)
 {
   bool supported = false;
+  const char *gfx_override = getenv("HSA_OVERRIDE_GFX_VERSION");
+  const bool has_gfx_override =
+      adapter_policy::HasValidGfxOverrideValue(gfx_override);
+  const bool enable_unsupported_adapters =
+      adapter_policy::IsEnabledValue(
+          getenv("LIBROCDXG_ENABLE_UNSUPPORTED_ADAPTERS"));
   D3DKMT_ENUMADAPTERS2 args = {0};
   NTSTATUS ret = DXCORE_CALL(D3DKMTEnumAdapters2(&args));
   if (ret != STATUS_SUCCESS)
@@ -555,6 +564,18 @@ NTSTATUS WDDMCreateDevices(std::vector<WDDMDevice *> &devices)
 
     supported = thunk_proxy::QueryAdapterSupported(query.DeviceIds.DeviceID);
 
+    if (!supported &&
+        adapter_policy::ShouldAllowUnsupportedAdapter(
+            query.DeviceIds.VendorID, query.DeviceIds.DeviceID,
+            has_gfx_override, enable_unsupported_adapters)) {
+      pr_warn("Allowing unsupported AMD adapter device_id=0x%04x because %s is set.\n",
+              query.DeviceIds.DeviceID,
+              adapter_policy::UnsupportedAdapterReason(
+                  query.DeviceIds.DeviceID, has_gfx_override,
+                  enable_unsupported_adapters));
+      supported = true;
+    }
+
     if (supported) {
       auto device = new WDDMDevice(
         info[i].hAdapter, info[i].AdapterLuid, devices.size() + 1);
@@ -582,6 +603,16 @@ bool WDDMDevice::ParseDeviceInfo() {
   ret = thunk_proxy::ParseAdapterInfo(adapter_, &device_info_);
   if (!ret)
     return false;
+
+  if (adapter_policy::ApplyAdapterInfoFallback(device_info_)) {
+    const auto *fallback =
+        adapter_policy::FindAdapterInfoFallback(device_info_.device_id);
+    if (fallback) {
+      pr_warn("Using fallback adapter info for device_id=0x%04x as gfx%d%d%d with %u CUs.\n",
+              fallback->device_id, fallback->major, fallback->minor,
+              fallback->stepping, fallback->compute_unit_count);
+    }
+  }
 
   return true;
 }

--- a/src/wddm/queue.cpp
+++ b/src/wddm/queue.cpp
@@ -731,7 +731,8 @@ ComputeQueue::KernelDispatchAqlToPm4(char *cpu, hsa_kernel_dispatch_packet_t *pa
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in KernelDispatch: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
+    pr_err("PM4 command buffer overflow in KernelDispatch: used %" PRIu64 " bytes, limit %u bytes\n",
+           static_cast<uint64_t>(i) - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -825,7 +826,8 @@ ComputeQueue::BarrierGenericAqlToPm4(char *cpu, hsa_barrier_and_packet_t *packet
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in BarrierGeneric: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
+    pr_err("PM4 command buffer overflow in BarrierGeneric: used %" PRIu64 " bytes, limit %u bytes\n",
+           static_cast<uint64_t>(i) - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -901,7 +903,8 @@ hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char *cpu, amd_aql_pm4_ib *pac
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in VendorSpecific: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
+    pr_err("PM4 command buffer overflow in VendorSpecific: used %" PRIu64 " bytes, limit %u bytes\n",
+           static_cast<uint64_t>(i) - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+add_executable(adapter_policy_test
+  adapter_policy_test.cpp
+  ${PROJECT_SOURCE_DIR}/src/wddm/adapter_policy.cpp)
+
+target_include_directories(adapter_policy_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/src)
+
+target_include_directories(adapter_policy_test SYSTEM PRIVATE ${WIN_SDK})
+
+target_compile_definitions(adapter_policy_test PRIVATE
+  LINUX
+  __AMD64__
+  LITTLEENDIAN_CPU
+  HSA_LARGE_MODEL)
+
+add_test(NAME adapter_policy_test COMMAND adapter_policy_test)
+
+add_executable(events_test
+  events_test.cpp
+  ${PROJECT_SOURCE_DIR}/src/events.cpp)
+
+target_include_directories(events_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/src)
+
+target_include_directories(events_test SYSTEM PRIVATE ${WIN_SDK})
+
+target_compile_definitions(events_test PRIVATE
+  LINUX
+  __AMD64__
+  LITTLEENDIAN_CPU
+  HSA_LARGE_MODEL)
+
+target_compile_options(events_test PRIVATE
+  -fPIC
+  -include ${PROJECT_SOURCE_DIR}/src/librocdxg.h)
+
+target_link_libraries(events_test PRIVATE pthread rt c ${CMAKE_DL_LIBS})
+
+add_test(NAME events_test COMMAND events_test)

--- a/tests/adapter_policy_test.cpp
+++ b/tests/adapter_policy_test.cpp
@@ -1,0 +1,92 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "wddm/adapter_policy.h"
+
+namespace {
+
+void Check(bool condition, const char *message) {
+  if (!condition) {
+    std::fprintf(stderr, "%s\n", message);
+    std::exit(1);
+  }
+}
+
+thunk_proxy::DeviceInfo MakeDeviceInfo(uint32_t device_id) {
+  thunk_proxy::DeviceInfo device_info = {};
+  device_info.device_id = device_id;
+  return device_info;
+}
+
+} // namespace
+
+int main() {
+  using namespace wsl::thunk::adapter_policy;
+
+  Check(FindAdapterInfoFallback(0x73EF) != nullptr,
+        "expected fallback entry for known device id");
+  Check(FindAdapterInfoFallback(0xFFFF) == nullptr,
+        "unexpected fallback entry for unknown device id");
+
+  Check(HasValidGfxOverrideValue("10.3.0"),
+        "valid gfx override should be accepted");
+  Check(!HasValidGfxOverrideValue("10.3"),
+        "short gfx override should be rejected");
+  Check(!HasValidGfxOverrideValue("bad"),
+        "non numeric gfx override should be rejected");
+  Check(!HasValidGfxOverrideValue("64.3.0"),
+        "out of range gfx override should be rejected");
+
+  Check(IsEnabledValue("1"), "1 should enable flag");
+  Check(IsEnabledValue("true"), "true should enable flag");
+  Check(IsEnabledValue("YES"), "YES should enable flag");
+  Check(!IsEnabledValue("0"), "0 should not enable flag");
+  Check(!IsEnabledValue(nullptr), "null should not enable flag");
+
+  Check(ShouldAllowUnsupportedAdapter(0x1002, 0x73EF, true, false),
+        "valid override should admit known AMD fallback device");
+  Check(ShouldAllowUnsupportedAdapter(0x1002, 0x73EF, false, true),
+        "explicit opt in should admit known AMD fallback device");
+  Check(!ShouldAllowUnsupportedAdapter(0x1002, 0xFFFF, true, true),
+        "unknown device should not be admitted");
+  Check(!ShouldAllowUnsupportedAdapter(0x10DE, 0x73EF, true, true),
+        "non AMD device should not be admitted");
+  Check(!ShouldAllowUnsupportedAdapter(0x1002, 0x73EF, false, false),
+        "known device should stay blocked without explicit opt in");
+
+  Check(std::strcmp(UnsupportedAdapterReason(0x73EF, true, false),
+                    "HSA_OVERRIDE_GFX_VERSION") == 0,
+        "override reason mismatch");
+  Check(std::strcmp(UnsupportedAdapterReason(0x73EF, false, true),
+                    "LIBROCDXG_ENABLE_UNSUPPORTED_ADAPTERS") == 0,
+        "opt in reason mismatch");
+
+  auto empty_device = MakeDeviceInfo(0x73EF);
+  Check(ApplyAdapterInfoFallback(empty_device),
+        "expected fallback metadata to populate missing fields");
+  Check(empty_device.major == 10 && empty_device.minor == 3 &&
+            empty_device.stepping == 2,
+        "unexpected fallback engine version");
+  Check(empty_device.compute_unit_count == 28,
+        "unexpected fallback compute unit count");
+
+  auto populated_device = MakeDeviceInfo(0x73EF);
+  populated_device.major = 9;
+  populated_device.minor = 9;
+  populated_device.stepping = 9;
+  populated_device.compute_unit_count = 99;
+  Check(!ApplyAdapterInfoFallback(populated_device),
+        "fallback should not overwrite existing metadata");
+  Check(populated_device.major == 9 && populated_device.minor == 9 &&
+            populated_device.stepping == 9,
+        "existing engine version should be preserved");
+  Check(populated_device.compute_unit_count == 99,
+        "existing compute unit count should be preserved");
+
+  auto unknown_device = MakeDeviceInfo(0xFFFF);
+  Check(!ApplyAdapterInfoFallback(unknown_device),
+        "unknown device should not receive fallback metadata");
+
+  return 0;
+}

--- a/tests/events_test.cpp
+++ b/tests/events_test.cpp
@@ -1,0 +1,135 @@
+#include <cstdio>
+#include <cstdlib>
+
+#include "librocdxg.h"
+
+hsakmtRuntime *dxg_runtime = nullptr;
+
+namespace {
+
+void Check(HSAKMT_STATUS actual, HSAKMT_STATUS expected, const char *message) {
+  if (actual != expected) {
+    std::fprintf(stderr, "%s: got %d expected %d\n", message, actual, expected);
+    std::exit(1);
+  }
+}
+
+void CheckState(HsaEvent *event, HSAuint64 expected, const char *message) {
+  if (event->EventData.HWData3 != expected) {
+    std::fprintf(stderr, "%s: got %llu expected %llu\n", message,
+                 static_cast<unsigned long long>(event->EventData.HWData3),
+                 static_cast<unsigned long long>(expected));
+    std::exit(1);
+  }
+}
+
+struct RuntimeGuard {
+  RuntimeGuard() {
+    runtime = new hsakmtRuntime();
+    runtime->dxg_open_count = 1;
+    runtime->is_forked = false;
+    dxg_runtime = runtime;
+  }
+
+  ~RuntimeGuard() { dxg_runtime = nullptr; }
+
+  hsakmtRuntime *runtime;
+};
+
+HsaEvent *CreateSignalEvent(bool manual_reset, bool is_signaled) {
+  HsaEventDescriptor descriptor = {};
+  descriptor.EventType = HSA_EVENTTYPE_SIGNAL;
+
+  HsaEvent *event = nullptr;
+  Check(hsaKmtCreateEvent(&descriptor, manual_reset, is_signaled, &event),
+        HSAKMT_STATUS_SUCCESS, "failed to create signal event");
+  return event;
+}
+
+} // namespace
+
+int main() {
+  RuntimeGuard runtime_guard;
+
+  {
+    HsaEventDescriptor descriptor = {};
+    descriptor.EventType = HSA_EVENTTYPE_MEMORY;
+    HsaEvent *event = nullptr;
+    Check(hsaKmtCreateEvent(&descriptor, false, false, &event),
+          HSAKMT_STATUS_NOT_SUPPORTED,
+          "unsupported event type should be rejected");
+  }
+
+  {
+    HsaEvent *event = CreateSignalEvent(true, false);
+    Check(hsaKmtSetEvent(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset set should succeed");
+    Check(hsaKmtQueryEventState(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset query should succeed");
+    CheckState(event, 1, "manual reset event should be signaled");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_SUCCESS,
+          "manual reset first wait should succeed");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_SUCCESS,
+          "manual reset second wait should succeed");
+    Check(hsaKmtResetEvent(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset reset should succeed");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "manual reset should time out after reset");
+    Check(hsaKmtDestroyEvent(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset destroy should succeed");
+  }
+
+  {
+    HsaEvent *event = CreateSignalEvent(false, false);
+    Check(hsaKmtSetEvent(event), HSAKMT_STATUS_SUCCESS,
+          "auto reset set should succeed");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_SUCCESS,
+          "auto reset first wait should succeed");
+    Check(hsaKmtQueryEventState(event), HSAKMT_STATUS_SUCCESS,
+          "auto reset query should succeed");
+    CheckState(event, 0, "auto reset event should be consumed after wait");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "auto reset second wait should time out");
+    Check(hsaKmtDestroyEvent(event), HSAKMT_STATUS_SUCCESS,
+          "auto reset destroy should succeed");
+  }
+
+  {
+    HsaEvent *events[2] = {CreateSignalEvent(false, false),
+                           CreateSignalEvent(false, false)};
+    uint64_t event_age = 99;
+
+    Check(hsaKmtSetEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "wait all set first event should succeed");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, true, 0, &event_age),
+          HSAKMT_STATUS_WAIT_TIMEOUT,
+          "wait all should time out when one event is unsignaled");
+    Check(hsaKmtWaitOnEvent(events[0], 0), HSAKMT_STATUS_SUCCESS,
+          "timed out wait all should preserve auto reset event state");
+
+    Check(hsaKmtSetEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "wait all re set first event should succeed");
+    Check(hsaKmtSetEvent(events[1]), HSAKMT_STATUS_SUCCESS,
+          "wait all set second event should succeed");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, true, 0, &event_age),
+          HSAKMT_STATUS_SUCCESS, "wait all should succeed when both are set");
+    Check(hsaKmtWaitOnEvent(events[0], 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "successful wait all should consume first auto reset event");
+    Check(hsaKmtWaitOnEvent(events[1], 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "successful wait all should consume second auto reset event");
+
+    Check(hsaKmtDestroyEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "destroy first wait all event should succeed");
+    Check(hsaKmtDestroyEvent(events[1]), HSAKMT_STATUS_SUCCESS,
+          "destroy second wait all event should succeed");
+  }
+
+  {
+    HsaEvent *null_event = nullptr;
+    Check(hsaKmtWaitOnMultipleEvents_Ext(&null_event, 1, true, 0, nullptr),
+          HSAKMT_STATUS_SUCCESS,
+          "single null event should preserve existing sleep behavior");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Motivation

This PR improves the WSL DXG adapter fallback path and replaces the current signal event stubs with signal event handling. It also adds targeted unit tests for the new behavior.

The intent is to preserve the default gating for unsupported adapters, make explicit opt in and override behavior more predictable, and provide an event implementation that is easier to review upstream. Related context: [ROCm/ROCm#1756](https://github.com/ROCm/ROCm/issues/1756).

Although the diff touches adapter policy, event handling, build configuration, and tests, the scope is intentionally narrow. The adapter policy changes are the functional fix, the event changes are required because initialization reaches those paths once the adapter is admitted, and the test wiring is included so the new functionality has upstream ready coverage.

## Technical Details

The main library changes are:

1. Adapter fallback handling was moved into a dedicated internal helper in `src/wddm/adapter_policy.cpp` and `src/wddm/adapter_policy.h`.
2. Unsupported adapter admission now stays limited to the known fallback device IDs `0x73E3` and `0x73EF`, which are treated as known WSL metadata gap cases rather than a general unsupported adapter allowlist.
3. This PR introduces `LIBROCDXG_ENABLE_UNSUPPORTED_ADAPTERS` as an explicit opt in for enumerating that limited fallback set during local validation and testing.
4. `HSA_OVERRIDE_GFX_VERSION` must now be valid before it affects adapter admission.
5. Fallback metadata only backfills missing adapter fields and does not overwrite parsed values.
6. The override target remains user controlled through `HSA_OVERRIDE_GFX_VERSION`.
7. `src/events.cpp` now implements `HSA_EVENTTYPE_SIGNAL` create, query, set, reset, single wait, and multi wait behavior instead of stubbed assertions.
8. Non signal event types are not claimed as supported by this PR. `hsaKmtCreateEvent` now rejects `HSA_EVENTTYPE_NODECHANGE`, `HSA_EVENTTYPE_DEVICESTATECHANGE`, `HSA_EVENTTYPE_HW_EXCEPTION`, `HSA_EVENTTYPE_SYSTEM_EVENT`, `HSA_EVENTTYPE_DEBUG_EVENT`, `HSA_EVENTTYPE_PROFILE_EVENT`, `HSA_EVENTTYPE_QUEUE_EVENT`, and `HSA_EVENTTYPE_MEMORY` with `HSAKMT_STATUS_NOT_SUPPORTED`.
9. `WaitOnAll` now delays auto reset consumption until the full wait succeeds, which avoids losing a signal on timeout.
10. `CMakeLists.txt` marks the Windows SDK include path as a system include.
11. src/wddm/queue.cpp fixes internal PM4 overflow log format strings to remove project side compiler warnings.
12. Focused unit coverage was added in `tests/adapter_policy_test.cpp` and `tests/events_test.cpp`.

## Test Plan

Test environment:

1. WSL 2
2. Ubuntu 24.04 under WSL DXG
3. ROCm 7.2.1 userspace
4. Affected AMD adapter device ID `0x73EF`

Validation steps:

1. Configure in WSL with:
   `cmake .. -DWIN_SDK:PATH='/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared'`
2. Build with:
   `cmake --build . -j4`
3. Run unit tests with:
   `ctest --output-on-failure`
4. On affected WSL hardware, run local runtime validation with:
   `rocminfo`
5. On affected WSL hardware, verify explicit unsupported adapter opt in:
   `LIBROCDXG_ENABLE_UNSUPPORTED_ADAPTERS=1 /opt/rocm/bin/rocm_agent_enumerator`
6. On affected WSL hardware, verify valid override path:
   `HSA_OVERRIDE_GFX_VERSION=10.3.0 /opt/rocm/bin/rocm_agent_enumerator`
7. On affected WSL hardware, verify invalid override does not loosen admission:
   `HSA_OVERRIDE_GFX_VERSION=bad rocminfo`

## Test Result

`ctest --output-on-failure` passed `2/2` tests:
`adapter_policy_test`
`events_test`

The unit tests explicitly cover:

1. valid and invalid override parsing
2. limited unsupported adapter admission for known fallback IDs
3. fallback metadata backfill behavior
4. rejection of non signal event types
5. manual reset signal event behavior
6. auto reset signal event behavior
7. `WaitOnAll` timeout behavior where an auto reset event must remain signaled if the full wait does not complete
8. `WaitOnAll` success behavior where auto reset events are consumed only after the full wait succeeds

Additional local runtime validation on affected WSL hardware also passed:

1. Default path still rejects unsupported adapters.
2. `LIBROCDXG_ENABLE_UNSUPPORTED_ADAPTERS=1` reports `gfx1032`.
3. `HSA_OVERRIDE_GFX_VERSION=10.3.0` reports `gfx1030`.
4. Invalid override input no longer changes adapter admission behavior.

The remaining `clock skew` build warnings only occurred when building from `/mnt/c` under WSL and are environmental rather than compiler warnings from this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.