### PR TITLE
dxg/wsl: refine signal event handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ list( PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules" )
 ## Include common cmake modules
 include ( utils )
 include ( GNUInstallDirs )
+include ( CTest )
 
 ## Setup the package version.
 get_version ( "${ROCDXG_VERSION}" )
@@ -313,3 +314,7 @@ cpack_add_component(binary
 cpack_add_component(dev
   DISPLAY_NAME "Development"
   DESCRIPTION "ROCDXG development files (pkgconfig and cmake)")
+
+if (BUILD_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -23,17 +23,195 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include <cstdio>
-#include <cassert>
-#include <thread>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace {
+
+std::atomic<HSA_EVENTID> g_next_event_id{1};
+
+class EventState {
+public:
+  EventState(bool manual_reset, bool signaled)
+      : signaled_(signaled), manual_reset_(manual_reset) {}
+
+  void Set() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      signaled_ = true;
+    }
+    if (manual_reset_)
+      condition_.notify_all();
+    else
+      condition_.notify_one();
+  }
+
+  void Reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    signaled_ = false;
+  }
+
+  void ConsumeIfAutoReset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!manual_reset_ && signaled_)
+      signaled_ = false;
+  }
+
+  bool IsSignaled() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return signaled_;
+  }
+
+  HSAKMT_STATUS Wait(HSAuint32 milliseconds) {
+    return WaitInternal(milliseconds, true);
+  }
+
+  HSAKMT_STATUS WaitUntilSignaled(HSAuint32 milliseconds) {
+    return WaitInternal(milliseconds, false);
+  }
+
+private:
+  HSAKMT_STATUS WaitInternal(HSAuint32 milliseconds, bool consume) {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    if (!signaled_) {
+      if (milliseconds == HSA_EVENTTIMEOUT_INFINITE) {
+        condition_.wait(lock, [this] { return signaled_; });
+      } else if (!condition_.wait_for(lock, std::chrono::milliseconds(milliseconds),
+                                      [this] { return signaled_; })) {
+        return HSAKMT_STATUS_WAIT_TIMEOUT;
+      }
+    }
+
+    if (consume && !manual_reset_)
+      signaled_ = false;
+
+    return HSAKMT_STATUS_SUCCESS;
+  }
+
+  mutable std::mutex mutex_;
+  std::condition_variable condition_;
+  bool signaled_;
+  bool manual_reset_;
+};
+
+bool IsSupportedEventType(HSA_EVENTTYPE event_type) {
+  return event_type == HSA_EVENTTYPE_SIGNAL;
+}
+
+EventState *GetEventState(HsaEvent *event) {
+  return reinterpret_cast<EventState *>(event->EventData.HWData1);
+}
+
+void SetSignaled(HsaEvent *event, bool signaled) {
+  event->EventData.HWData3 = signaled ? 1 : 0;
+}
+
+HSAKMT_STATUS WaitOnMultipleEvents(EventState *states[], HSAuint32 num_events,
+                                   bool wait_on_all, HSAuint32 milliseconds,
+                                   uint64_t *event_age) {
+  if (!states || !num_events)
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (event_age)
+    *event_age = 0;
+
+  auto remaining_ms = milliseconds;
+  auto start = std::chrono::steady_clock::now();
+  const bool infinite = milliseconds == HSA_EVENTTIMEOUT_INFINITE;
+
+  if (wait_on_all) {
+    // Delay auto-reset consumption until every event has been observed so a
+    // timed out aggregate wait does not clear a signal that another waiter
+    // still needs to see.
+    for (HSAuint32 i = 0; i < num_events; i++) {
+      if (!states[i])
+        return HSAKMT_STATUS_INVALID_HANDLE;
+
+      auto status =
+          states[i]->WaitUntilSignaled(infinite ? HSA_EVENTTIMEOUT_INFINITE
+                                                : remaining_ms);
+      if (status != HSAKMT_STATUS_SUCCESS)
+        return status;
+
+      if (!infinite) {
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed_ms = static_cast<HSAuint32>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - start)
+                .count());
+        remaining_ms =
+            elapsed_ms >= milliseconds ? 0 : milliseconds - elapsed_ms;
+      }
+    }
+
+    for (HSAuint32 i = 0; i < num_events; i++)
+      states[i]->ConsumeIfAutoReset();
+
+    return HSAKMT_STATUS_SUCCESS;
+  }
+
+  while (true) {
+    for (HSAuint32 i = 0; i < num_events; i++) {
+      if (!states[i])
+        return HSAKMT_STATUS_INVALID_HANDLE;
+
+      auto status = states[i]->Wait(0);
+      if (status == HSAKMT_STATUS_SUCCESS)
+        return status;
+      if (status != HSAKMT_STATUS_WAIT_TIMEOUT)
+        return status;
+    }
+
+    if (!infinite) {
+      auto now = std::chrono::steady_clock::now();
+      auto elapsed_ms = static_cast<HSAuint32>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(now - start)
+              .count());
+      if (elapsed_ms >= milliseconds)
+        return HSAKMT_STATUS_WAIT_TIMEOUT;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+} // namespace
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtCreateEvent(HsaEventDescriptor *EventDesc,
                                           bool ManualReset, bool IsSignaled,
                                           HsaEvent **Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
-  assert(false);
+
+  if (!EventDesc || !Event)
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (!IsSupportedEventType(EventDesc->EventType))
+    return HSAKMT_STATUS_NOT_SUPPORTED;
+
+  auto *event = reinterpret_cast<HsaEvent *>(calloc(1, sizeof(HsaEvent)));
+  if (!event)
+    return HSAKMT_STATUS_NO_MEMORY;
+
+  auto *state = new EventState(ManualReset, IsSignaled);
+  if (!state) {
+    free(event);
+    return HSAKMT_STATUS_NO_MEMORY;
+  }
+
+  event->EventId = g_next_event_id.fetch_add(1, std::memory_order_relaxed);
+  event->EventData.EventType = EventDesc->EventType;
+  event->EventData.EventData.SyncVar = EventDesc->SyncVar;
+  event->EventData.HWData1 = reinterpret_cast<HSAuint64>(state);
+  event->EventData.HWData2 = ManualReset ? 1 : 0;
+  SetSignaled(event, IsSignaled);
+
+  *Event = event;
   return HSAKMT_STATUS_SUCCESS;
 }
 
@@ -42,38 +220,50 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyEvent(HsaEvent *Event) {
   if (!Event)
     return HSAKMT_STATUS_SUCCESS;
 
-  pr_warn_once("not supported\n");
-  assert(false);
+  delete GetEventState(Event);
+
+  free(Event);
   return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtSetEvent(HsaEvent *Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
   if (!Event)
     return HSAKMT_STATUS_INVALID_HANDLE;
 
-  assert(false);
+  auto *state = GetEventState(Event);
+  if (!state)
+    return HSAKMT_STATUS_INVALID_HANDLE;
+
+  state->Set();
+  SetSignaled(Event, true);
   return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtResetEvent(HsaEvent *Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
   if (!Event)
     return HSAKMT_STATUS_INVALID_HANDLE;
 
-  assert(false);
+  auto *state = GetEventState(Event);
+  if (!state)
+    return HSAKMT_STATUS_INVALID_HANDLE;
+
+  state->Reset();
+  SetSignaled(Event, state->IsSignaled());
   return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtQueryEventState(HsaEvent *Event) {
   CHECK_DXG_OPEN();
-  pr_warn_once("not supported\n");
   if (!Event)
     return HSAKMT_STATUS_INVALID_HANDLE;
 
-  assert(false);
+  auto *state = GetEventState(Event);
+  if (!state)
+    return HSAKMT_STATUS_INVALID_HANDLE;
+
+  SetSignaled(Event, state->IsSignaled());
   return HSAKMT_STATUS_SUCCESS;
 }
 
@@ -107,16 +297,32 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtWaitOnMultipleEvents_Ext(HsaEvent *Events[],
                                                        uint64_t *event_age) {
   CHECK_DXG_OPEN();
 
-  if (!Events)
-    return HSAKMT_STATUS_INVALID_HANDLE;
+  if (!Events || !NumEvents)
+    return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (event_age)
+    *event_age = 0;
 
   if (NumEvents == 1 && Events[0] == nullptr) {
     std::this_thread::sleep_for(std::chrono::microseconds(20));
     return HSAKMT_STATUS_SUCCESS;
   }
 
-  assert(false);
-  return HSAKMT_STATUS_SUCCESS;
+  std::vector<EventState *> states(NumEvents);
+  for (HSAuint32 i = 0; i < NumEvents; i++) {
+    if (!Events[i] || !GetEventState(Events[i]))
+      return HSAKMT_STATUS_INVALID_HANDLE;
+    states[i] = GetEventState(Events[i]);
+  }
+
+  auto status = WaitOnMultipleEvents(states.data(), NumEvents, WaitOnAll,
+                                     Milliseconds, event_age);
+  if (status == HSAKMT_STATUS_SUCCESS) {
+    for (HSAuint32 i = 0; i < NumEvents; i++)
+      SetSignaled(Events[i], states[i]->IsSignaled());
+  }
+
+  return status;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSMI(HSAuint32 NodeId, int *fd) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_executable(events_test
+  events_test.cpp
+  ${PROJECT_SOURCE_DIR}/src/events.cpp)
+
+target_include_directories(events_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/src)
+
+target_include_directories(events_test SYSTEM PRIVATE ${WIN_SDK})
+
+target_compile_definitions(events_test PRIVATE
+  LINUX
+  __AMD64__
+  LITTLEENDIAN_CPU
+  HSA_LARGE_MODEL)
+
+target_compile_options(events_test PRIVATE
+  -fPIC
+  -include ${PROJECT_SOURCE_DIR}/src/librocdxg.h)
+
+target_link_libraries(events_test PRIVATE pthread rt c ${CMAKE_DL_LIBS})
+
+add_test(NAME events_test COMMAND events_test)

--- a/tests/events_test.cpp
+++ b/tests/events_test.cpp
@@ -14,6 +14,15 @@ void Check(HSAKMT_STATUS actual, HSAKMT_STATUS expected, const char *message) {
   }
 }
 
+void CheckValue(uint64_t actual, uint64_t expected, const char *message) {
+  if (actual != expected) {
+    std::fprintf(stderr, "%s: got %llu expected %llu\n", message,
+                 static_cast<unsigned long long>(actual),
+                 static_cast<unsigned long long>(expected));
+    std::exit(1);
+  }
+}
+
 void CheckState(HsaEvent *event, HSAuint64 expected, const char *message) {
   if (event->EventData.HWData3 != expected) {
     std::fprintf(stderr, "%s: got %llu expected %llu\n", message,
@@ -50,6 +59,46 @@ HsaEvent *CreateSignalEvent(bool manual_reset, bool is_signaled) {
 
 int main() {
   RuntimeGuard runtime_guard;
+
+  {
+    HsaEventDescriptor descriptor = {};
+    descriptor.EventType = HSA_EVENTTYPE_SIGNAL;
+    HsaEvent *event = nullptr;
+    HsaEvent invalid_event = {};
+    HsaEvent *events[1] = {&invalid_event};
+
+    Check(hsaKmtCreateEvent(nullptr, false, false, &event),
+          HSAKMT_STATUS_INVALID_PARAMETER,
+          "null event descriptor should be rejected");
+    Check(hsaKmtCreateEvent(&descriptor, false, false, nullptr),
+          HSAKMT_STATUS_INVALID_PARAMETER,
+          "null event output should be rejected");
+    Check(hsaKmtDestroyEvent(nullptr), HSAKMT_STATUS_SUCCESS,
+          "destroying a null event should succeed");
+    Check(hsaKmtSetEvent(nullptr), HSAKMT_STATUS_INVALID_HANDLE,
+          "null event set should be rejected");
+    Check(hsaKmtSetEvent(&invalid_event), HSAKMT_STATUS_INVALID_HANDLE,
+          "event without backing state should be rejected on set");
+    Check(hsaKmtResetEvent(nullptr), HSAKMT_STATUS_INVALID_HANDLE,
+          "null event reset should be rejected");
+    Check(hsaKmtResetEvent(&invalid_event), HSAKMT_STATUS_INVALID_HANDLE,
+          "event without backing state should be rejected on reset");
+    Check(hsaKmtQueryEventState(nullptr), HSAKMT_STATUS_INVALID_HANDLE,
+          "null event query should be rejected");
+    Check(hsaKmtQueryEventState(&invalid_event), HSAKMT_STATUS_INVALID_HANDLE,
+          "event without backing state should be rejected on query");
+    Check(hsaKmtWaitOnEvent(nullptr, 0), HSAKMT_STATUS_INVALID_HANDLE,
+          "null event wait should be rejected");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(nullptr, 1, true, 0, nullptr),
+          HSAKMT_STATUS_INVALID_PARAMETER,
+          "null event array should be rejected");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 0, true, 0, nullptr),
+          HSAKMT_STATUS_INVALID_PARAMETER,
+          "zero event count should be rejected");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 1, true, 0, nullptr),
+          HSAKMT_STATUS_INVALID_HANDLE,
+          "event without backing state should be rejected in multi wait");
+  }
 
   {
     HsaEventDescriptor descriptor = {};
@@ -95,6 +144,42 @@ int main() {
   }
 
   {
+    HsaEvent *event = CreateSignalEvent(false, true);
+    uint64_t event_age = 99;
+
+    Check(hsaKmtWaitOnEvent_Ext(event, 0, &event_age), HSAKMT_STATUS_SUCCESS,
+          "pre signaled auto reset wait should succeed");
+    CheckState(event, 0, "pre signaled auto reset event should be consumed");
+    CheckValue(event_age, 0, "event age should be cleared on wait success");
+    Check(hsaKmtDestroyEvent(event), HSAKMT_STATUS_SUCCESS,
+          "pre signaled auto reset destroy should succeed");
+  }
+
+  {
+    HsaEvent *events[2] = {CreateSignalEvent(false, false),
+                           CreateSignalEvent(false, false)};
+    uint64_t event_age = 99;
+
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, false, 0, &event_age),
+          HSAKMT_STATUS_WAIT_TIMEOUT,
+          "wait any should time out when no events are signaled");
+    CheckValue(event_age, 0, "event age should be cleared on wait any timeout");
+
+    event_age = 99;
+    Check(hsaKmtSetEvent(events[1]), HSAKMT_STATUS_SUCCESS,
+          "wait any set second event should succeed");
+    Check(hsaKmtWaitOnMultipleEvents(events, 2, false, 0),
+          HSAKMT_STATUS_SUCCESS,
+          "wait any should succeed when one event is signaled");
+    Check(hsaKmtWaitOnEvent(events[1], 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "wait any should consume the winning auto reset event");
+    Check(hsaKmtDestroyEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "destroy first wait any event should succeed");
+    Check(hsaKmtDestroyEvent(events[1]), HSAKMT_STATUS_SUCCESS,
+          "destroy second wait any event should succeed");
+  }
+
+  {
     HsaEvent *events[2] = {CreateSignalEvent(false, false),
                            CreateSignalEvent(false, false)};
     uint64_t event_age = 99;
@@ -104,15 +189,18 @@ int main() {
     Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, true, 0, &event_age),
           HSAKMT_STATUS_WAIT_TIMEOUT,
           "wait all should time out when one event is unsignaled");
+    CheckValue(event_age, 0, "event age should be cleared on wait all timeout");
     Check(hsaKmtWaitOnEvent(events[0], 0), HSAKMT_STATUS_SUCCESS,
           "timed out wait all should preserve auto reset event state");
 
+    event_age = 99;
     Check(hsaKmtSetEvent(events[0]), HSAKMT_STATUS_SUCCESS,
           "wait all re set first event should succeed");
     Check(hsaKmtSetEvent(events[1]), HSAKMT_STATUS_SUCCESS,
           "wait all set second event should succeed");
     Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, true, 0, &event_age),
           HSAKMT_STATUS_SUCCESS, "wait all should succeed when both are set");
+    CheckValue(event_age, 0, "event age should be cleared on wait all success");
     Check(hsaKmtWaitOnEvent(events[0], 0), HSAKMT_STATUS_WAIT_TIMEOUT,
           "successful wait all should consume first auto reset event");
     Check(hsaKmtWaitOnEvent(events[1], 0), HSAKMT_STATUS_WAIT_TIMEOUT,

--- a/tests/events_test.cpp
+++ b/tests/events_test.cpp
@@ -1,0 +1,135 @@
+#include <cstdio>
+#include <cstdlib>
+
+#include "librocdxg.h"
+
+hsakmtRuntime *dxg_runtime = nullptr;
+
+namespace {
+
+void Check(HSAKMT_STATUS actual, HSAKMT_STATUS expected, const char *message) {
+  if (actual != expected) {
+    std::fprintf(stderr, "%s: got %d expected %d\n", message, actual, expected);
+    std::exit(1);
+  }
+}
+
+void CheckState(HsaEvent *event, HSAuint64 expected, const char *message) {
+  if (event->EventData.HWData3 != expected) {
+    std::fprintf(stderr, "%s: got %llu expected %llu\n", message,
+                 static_cast<unsigned long long>(event->EventData.HWData3),
+                 static_cast<unsigned long long>(expected));
+    std::exit(1);
+  }
+}
+
+struct RuntimeGuard {
+  RuntimeGuard() {
+    runtime = new hsakmtRuntime();
+    runtime->dxg_open_count = 1;
+    runtime->is_forked = false;
+    dxg_runtime = runtime;
+  }
+
+  ~RuntimeGuard() { dxg_runtime = nullptr; }
+
+  hsakmtRuntime *runtime;
+};
+
+HsaEvent *CreateSignalEvent(bool manual_reset, bool is_signaled) {
+  HsaEventDescriptor descriptor = {};
+  descriptor.EventType = HSA_EVENTTYPE_SIGNAL;
+
+  HsaEvent *event = nullptr;
+  Check(hsaKmtCreateEvent(&descriptor, manual_reset, is_signaled, &event),
+        HSAKMT_STATUS_SUCCESS, "failed to create signal event");
+  return event;
+}
+
+} // namespace
+
+int main() {
+  RuntimeGuard runtime_guard;
+
+  {
+    HsaEventDescriptor descriptor = {};
+    descriptor.EventType = HSA_EVENTTYPE_MEMORY;
+    HsaEvent *event = nullptr;
+    Check(hsaKmtCreateEvent(&descriptor, false, false, &event),
+          HSAKMT_STATUS_NOT_SUPPORTED,
+          "unsupported event type should be rejected");
+  }
+
+  {
+    HsaEvent *event = CreateSignalEvent(true, false);
+    Check(hsaKmtSetEvent(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset set should succeed");
+    Check(hsaKmtQueryEventState(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset query should succeed");
+    CheckState(event, 1, "manual reset event should be signaled");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_SUCCESS,
+          "manual reset first wait should succeed");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_SUCCESS,
+          "manual reset second wait should succeed");
+    Check(hsaKmtResetEvent(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset reset should succeed");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "manual reset should time out after reset");
+    Check(hsaKmtDestroyEvent(event), HSAKMT_STATUS_SUCCESS,
+          "manual reset destroy should succeed");
+  }
+
+  {
+    HsaEvent *event = CreateSignalEvent(false, false);
+    Check(hsaKmtSetEvent(event), HSAKMT_STATUS_SUCCESS,
+          "auto reset set should succeed");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_SUCCESS,
+          "auto reset first wait should succeed");
+    Check(hsaKmtQueryEventState(event), HSAKMT_STATUS_SUCCESS,
+          "auto reset query should succeed");
+    CheckState(event, 0, "auto reset event should be consumed after wait");
+    Check(hsaKmtWaitOnEvent(event, 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "auto reset second wait should time out");
+    Check(hsaKmtDestroyEvent(event), HSAKMT_STATUS_SUCCESS,
+          "auto reset destroy should succeed");
+  }
+
+  {
+    HsaEvent *events[2] = {CreateSignalEvent(false, false),
+                           CreateSignalEvent(false, false)};
+    uint64_t event_age = 99;
+
+    Check(hsaKmtSetEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "wait all set first event should succeed");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, true, 0, &event_age),
+          HSAKMT_STATUS_WAIT_TIMEOUT,
+          "wait all should time out when one event is unsignaled");
+    Check(hsaKmtWaitOnEvent(events[0], 0), HSAKMT_STATUS_SUCCESS,
+          "timed out wait all should preserve auto reset event state");
+
+    Check(hsaKmtSetEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "wait all re set first event should succeed");
+    Check(hsaKmtSetEvent(events[1]), HSAKMT_STATUS_SUCCESS,
+          "wait all set second event should succeed");
+    Check(hsaKmtWaitOnMultipleEvents_Ext(events, 2, true, 0, &event_age),
+          HSAKMT_STATUS_SUCCESS, "wait all should succeed when both are set");
+    Check(hsaKmtWaitOnEvent(events[0], 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "successful wait all should consume first auto reset event");
+    Check(hsaKmtWaitOnEvent(events[1], 0), HSAKMT_STATUS_WAIT_TIMEOUT,
+          "successful wait all should consume second auto reset event");
+
+    Check(hsaKmtDestroyEvent(events[0]), HSAKMT_STATUS_SUCCESS,
+          "destroy first wait all event should succeed");
+    Check(hsaKmtDestroyEvent(events[1]), HSAKMT_STATUS_SUCCESS,
+          "destroy second wait all event should succeed");
+  }
+
+  {
+    HsaEvent *null_event = nullptr;
+    Check(hsaKmtWaitOnMultipleEvents_Ext(&null_event, 1, true, 0, nullptr),
+          HSAKMT_STATUS_SUCCESS,
+          "single null event should preserve existing sleep behavior");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Motivation

This PR implements signal event handling in the DXG/WSL runtime and adds focused unit coverage for the new behavior.

It replaces the current signal event stubs with bounded, testable behavior for `HSA_EVENTTYPE_SIGNAL`.

## Technical Details

1. `src/events.cpp` now implements `HSA_EVENTTYPE_SIGNAL` create, destroy, set, reset, query, single wait, and multi event wait behavior.
2. `WaitOnAll` now delays auto reset consumption until the full wait succeeds, which prevents a timeout from clearing a signal that another waiter still needs to observe.
3. `CMakeLists.txt` enables test builds with `BUILD_TESTING`, and `tests/CMakeLists.txt` adds an `events_test` target.
4. `tests/events_test.cpp` adds focused coverage for event type validation, manual reset behavior, auto reset behavior, `WaitOnAll` timeout semantics, and successful `WaitOnAll` consumption.

## Test Plan

1. Test environment:
   `WSL 2`, `Ubuntu 24.04`
2. Configure in WSL with:
   `cmake .. -DWIN_SDK:PATH='/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared'`
3. Build with:
   `cmake --build . -j4`
4. Run unit tests with:
   `ctest --output-on-failure`

## Test Result

1. Local configure and build completed successfully.
2. `ctest --output-on-failure` passed `1/1` test.
3. `events_test` passed.
4. The test suite explicitly covers the `WaitOnAll` timeout path to verify that auto reset events are not consumed unless the aggregate wait succeeds.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Target the `develop` branch.
- [x] Verify the code builds successfully in WSL.
- [x] Add unit coverage for new functionality.
- [x] Run `ctest --output-on-failure`.
