### PR TITLE
chore: fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,8 +136,9 @@ target_include_directories( ${ROCDXG_TARGET}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-  ${WIN_SDK}
   ${CMAKE_CURRENT_SOURCE_DIR}/src )
+
+target_include_directories( ${ROCDXG_TARGET} SYSTEM PRIVATE ${WIN_SDK} )
 
 add_compile_definitions(LINUX __AMD64__ LITTLEENDIAN_CPU HSA_LARGE_MODEL)
 

--- a/amdsmi/src/CMakeLists.txt
+++ b/amdsmi/src/CMakeLists.txt
@@ -46,6 +46,8 @@ target_include_directories(${AMD_SMI} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../
     ${PROJECT_SOURCE_DIR}/common/shared_mutex
     ${PROJECT_SOURCE_DIR}/../include
+)
+target_include_directories(${AMD_SMI} SYSTEM PRIVATE
     ${WIN_SDK}
 )
 if(WIN_SDK)

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -44,9 +44,9 @@ target_include_directories(dxg_shared
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-    PRIVATE
-        ${WIN_SDK}
 )
+
+target_include_directories(dxg_shared SYSTEM PRIVATE ${WIN_SDK})
 
 target_compile_options(dxg_shared PRIVATE
     -fPIC

--- a/shared/src/dxcore_loader.cpp
+++ b/shared/src/dxcore_loader.cpp
@@ -13,9 +13,7 @@ namespace thunk {
 namespace dxcore {
 
 DxcoreLoader::DxcoreLoader()
-    : dxcore_handle_(nullptr)
-    , init_flag_()
-    , pfn_D3DKMTCreateAllocation2(nullptr)
+    : pfn_D3DKMTCreateAllocation2(nullptr)
     , pfn_D3DKMTDestroyAllocation2(nullptr)
     , pfn_D3DKMTMapGpuVirtualAddress(nullptr)
     , pfn_D3DKMTReserveGpuVirtualAddress(nullptr)
@@ -48,7 +46,9 @@ DxcoreLoader::DxcoreLoader()
     , pfn_D3DKMTDestroyHwQueue(nullptr)
     , pfn_D3DKMTSubmitCommandToHwQueue(nullptr)
     , pfn_D3DKMTEnumProcesses(nullptr)
-    , pfn_D3DKMTQueryVideoMemoryInfo(nullptr) {
+    , pfn_D3DKMTQueryVideoMemoryInfo(nullptr)
+    , dxcore_handle_(nullptr)
+    , init_flag_() {
 }
 
 DxcoreLoader::~DxcoreLoader() {

--- a/src/wddm/queue.cpp
+++ b/src/wddm/queue.cpp
@@ -623,7 +623,7 @@ ComputeQueue::KernelDispatchAqlToPm4(char *cpu, hsa_kernel_dispatch_packet_t *pa
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   int major = device->Major();
-  int i = ib_size;
+  uint32_t i = ib_size;
 
   const amd_kernel_code_t* kernel_object =
     (const amd_kernel_code_t *)GetKernelObjAddr(packet->kernel_object);
@@ -731,7 +731,7 @@ ComputeQueue::KernelDispatchAqlToPm4(char *cpu, hsa_kernel_dispatch_packet_t *pa
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in KernelDispatch: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
+    pr_err("PM4 command buffer overflow in KernelDispatch: used %lu bytes, limit %u bytes\n", i - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -785,7 +785,7 @@ ComputeQueue::BarrierGenericAqlToPm4(char *cpu, hsa_barrier_and_packet_t *packet
   }
 
   int major = device->Major();
-  int i = ib_size;
+  uint32_t i = ib_size;
 
   if (packet->completion_signal.handle != 0) {
     amd_signal_t *signal = (amd_signal_t *)packet->completion_signal.handle;
@@ -825,7 +825,7 @@ ComputeQueue::BarrierGenericAqlToPm4(char *cpu, hsa_barrier_and_packet_t *packet
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in BarrierGeneric: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
+    pr_err("PM4 command buffer overflow in BarrierGeneric: used %lu bytes, limit %u bytes\n", i - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -851,7 +851,7 @@ hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char *cpu, amd_aql_pm4_ib *pac
     pr_debug("pm4_addr[%d]=%#x\n", i, pm4_addr[i]);
   }
 
-  int i = ib_size;
+  uint32_t i = ib_size;
 
   if (dxg_runtime->vendor_packet_process) {
     int major = device->Major();
@@ -901,7 +901,7 @@ hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char *cpu, amd_aql_pm4_ib *pac
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in VendorSpecific: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
+    pr_err("PM4 command buffer overflow in VendorSpecific: used %lu bytes, limit %u bytes\n", i - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 


### PR DESCRIPTION
## Motivation

Fix warning spam.

## Technical Details

### 1. `ib_size` type warnings

```
/home/apophis/librocdxg/src/wddm/queue.cpp:904:66: note: format string is defined here
  904 |     pr_err("PM4 command buffer overflow in VendorSpecific: used %d bytes, limit %d bytes\n", i - ib_size, cmdbuf_aql_frame_size);
      |                                                                 ~^
      |                                                                  |
      |                                                                  int
      |                                                                 %ld
```

- Fix: fix type.

---

### 2. `-Wreorder` warning

```
/home/apophis/librocdxg/shared/include/dxcore_loader.h: In constructor ‘wsl::thunk::dxcore::DxcoreLoader::DxcoreLoader()’:
/home/apophis/librocdxg/shared/include/dxcore_loader.h:143:20: warning: ‘wsl::thunk::dxcore::DxcoreLoader::init_flag_’ will be initialized after [-Wreorder]
  143 |     std::once_flag init_flag_;  // For thread-safe initialization
      |                    ^~~~~~~~~~
/home/apophis/librocdxg/shared/include/dxcore_loader.h:49:37: warning:   ‘NTSTATUS (* wsl::thunk::dxcore::DxcoreLoader::pfn_D3DKMTCreateAllocation2)(void*)’ [-Wreorder]
   49 | #define DXCORE_PFN(function_name)   pfn_##function_name
      |                                     ^~~~
/home/apophis/librocdxg/shared/include/dxcore_loader.h:100:42: note: in expansion of macro ‘DXCORE_PFN’
  100 |     DXCORE_DEF(D3DKMTCreateAllocation2)* DXCORE_PFN(D3DKMTCreateAllocation2);
      |                                          ^~~~~~~~~~
/home/apophis/librocdxg/shared/src/dxcore_loader.cpp:15:1: warning:   when initialized here [-Wreorder]
   15 | DxcoreLoader::DxcoreLoader()
      | ^~~~~~~~~~~~
```

- Fix: reorder in `DxcoreLoader::DxcoreLoader()`.

---

### 3. `-Wunknown-pragmas`

There are many MSVC-specific pragmas `#pragma warning`:

```
/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared/d3dkmdt.h:30: warning: ignoring ‘#pragma warning ’ [-Wunknown-pragmas]
   30 | #pragma warning(disable:4214)   // nonstandard extension used: bit field types other than int
      | 
/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared/d3dkmdt.h:2505: warning: ignoring ‘#pragma warning ’ [-Wunknown-pragmas]
 2505 | #pragma warning(pop)
      | 
/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared/d3dkmthk.h:17: warning: ignoring ‘#pragma warning ’ [-Wunknown-pragmas]
   17 | #pragma warning(push)
      | 
```

and so on, especially this one:

```
/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared/d3dkmdt.h:551:51: warning: ‘_D3DKMDT_VIDEO_SIGNAL_INFO::<unnamed union>::<unnamed struct>::ScanLineOrdering’ is too small to hold all values of ‘D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING’ {aka ‘enum _D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING’}
  551 |             D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING ScanLineOrdering : 3;
      |                                                   ^~~~~~~~~~~~~~~~
```

MSVC use `#pragma warning(disable:4201)` to suppress it:

```
/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared/d3dkmdt.h:29: warning: ignoring ‘#pragma warning ’ [-Wunknown-pragmas]
   29 | #pragma warning(disable:4201) // anonymous unions warning
      | 
```

but GCC doesn't recognize it.

- Fix: use CMake's `SYSTEM` keyword for the `${WIN_SDK}` include directory, which tells GCC to treat those headers as system headers (equivalent to `-isystem`). This suppresses warnings from Windows SDK headers while keeping warnings from project code fully active.

## Test Plan

No functional changes.

## Test Result

Compilation completed without warnings.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
