### PR TITLE
Add gfx11.0.3 and gfx11.5.2 to supported device list

### DIFF
--- a/shared/src/utils.cpp
+++ b/shared/src/utils.cpp
@@ -17,6 +17,8 @@ const struct GfxipTable kGfxipTable[] = {
   { 0x7551, 12, 0, 1 },
   { 0x150E, 11, 5, 0 },
   { 0x1586, 11, 5, 1 },
+  { 0x1114, 11, 5, 2 },
+  { 0x1900, 11, 0, 3 },
 };
 
 const int kGfxipTableSize = sizeof(kGfxipTable) / sizeof(kGfxipTable[0]);


### PR DESCRIPTION
## Motivation

Add support for new GFX IP variants so that GPUs with these device IDs are recognized by QueryAdapterSupported() and can be used on WSL.

## Technical Details

Add PCI device IDs 0x1900 (GFX 11.0.3) and 0x1114 (GFX 11.5.2) to kGfxipTable.

## Test Result

Verified that QueryAdapterSupported() correctly returns true for both new device IDs on the respective hardware.

