### PR TITLE
build: add ROCDXG_VERSION_PRERELEASE option for pre-release packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ set ( ROCDXG_COMPONENT "lib${ROCDXG}" )
 set ( ROCDXG_TARGET "${ROCDXG}" )
 set ( ROCDXG_VERSION "1.1.2")
 
+# Optional pre-release suffix (e.g. -DROCDXG_VERSION_PRERELEASE=rc1 produces 1.1.2~rc1).
+# Leave empty for a normal release build (1.1.2).
+set ( ROCDXG_VERSION_PRERELEASE "" CACHE STRING "Pre-release suffix appended to package version (e.g. rc1). Empty for release." )
+
 project ( ${ROCDXG_TARGET} VERSION ${ROCDXG_VERSION} )
 # Project/version initialized; expose version to code via target defs below
 
@@ -270,6 +274,12 @@ install ( FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDI
 
 # Prepare final version for the CPACK use
 set(PACKAGE_VERSION_STR "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+if ( NOT "${ROCDXG_VERSION_PRERELEASE}" STREQUAL "" )
+    string ( TOLOWER "${ROCDXG_VERSION_PRERELEASE}" _ROCDXG_VERSION_PRERELEASE_LC )
+    # Use Debian's '~' separator so pre-releases sort BEFORE the final release.
+    set(PACKAGE_VERSION_STR "${PACKAGE_VERSION_STR}~${_ROCDXG_VERSION_PRERELEASE_LC}")
+    message(STATUS "Building pre-release version: ${PACKAGE_VERSION_STR}")
+endif()
 set(CPACK_PACKAGE_VERSION "${PACKAGE_VERSION_STR}")
 
 # Debian package specific variables


### PR DESCRIPTION
Introduce a CMake cache variable ROCDXG_VERSION_PRERELEASE that, when set (e.g. -DROCDXG_VERSION_PRERELEASE=rc1), appends "~<suffix>" to CPACK_PACKAGE_VERSION, producing packages such as rocdxg-roct_1.1.2~rc1_amd64.deb. When unset, normal release packages (rocdxg-roct_1.1.2_amd64.deb) are produced unchanged.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
