### PR TITLE
shared: fix duplicate include guard and enforce rooted include paths

### DIFF
--- a/amdsmi/src/amd_smi/amd_smi.cc
+++ b/amdsmi/src/amd_smi/amd_smi.cc
@@ -56,9 +56,9 @@
 #include "amd_smi/impl/amd_smi_uuid.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 
-#include "dxcore_loader.h"
-#include "platform.h"
-#include "device.h"
+#include "shared/include/dxcore_loader.h"
+#include "shared/include/platform.h"
+#include "shared/include/device.h"
 
 // a global instance of std::mutex to protect data passed during threads
 std::mutex myMutex;

--- a/include/impl/wddm/device.h
+++ b/include/impl/wddm/device.h
@@ -50,11 +50,11 @@
 #include <memory>
 #include <vector>
 
-#include "d3dkmt_types.h"
-#include "thunk_proxy/thunk_proxy.h"
+#include "shared/include/d3dkmt_types.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
 #include "impl/wddm/va_mgr.h"
-#include "status.h"
-#include "d3dkmt_types.h"
+#include "shared/include/status.h"
+#include "shared/include/d3dkmt_types.h"
 #include "impl/wddm/gpu_memory.h"
 #include "impl/wddm/cmd_util.h"
 

--- a/include/impl/wddm/gpu_memory.h
+++ b/include/impl/wddm/gpu_memory.h
@@ -46,9 +46,9 @@
 #include <cstddef>
 #include <cstdint>
 #include "util/utils.h"
-#include "d3dkmt_types.h"
-#include "thunks.h"
-#include "thunk_proxy/thunk_proxy.h"
+#include "shared/include/d3dkmt_types.h"
+#include "shared/include/thunks.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
 
 namespace wsl {
 namespace thunk {

--- a/include/impl/wddm/queue.h
+++ b/include/impl/wddm/queue.h
@@ -47,7 +47,7 @@
 #include <iostream>
 #include <queue>
 #include <utility>
-#include "d3dkmt_types.h"
+#include "shared/include/d3dkmt_types.h"
 #include "impl/wddm/device.h"
 #include "impl/wddm/gpu_memory.h"
 #include "impl/hsa/hsa_ext_amd.h"

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -42,8 +42,10 @@ set_target_properties(dxg_shared PROPERTIES
 
 target_include_directories(dxg_shared
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<INSTALL_INTERFACE:>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_include_directories(dxg_shared SYSTEM PRIVATE ${WIN_SDK})

--- a/shared/include/constants.h
+++ b/shared/include/constants.h
@@ -43,7 +43,7 @@
 #ifndef _WSL_THUNK_INC_CONSTANTS_H_
 #define _WSL_THUNK_INC_CONSTANTS_H_
 
-#include "d3dkmt_types.h"
+#include "shared/include/d3dkmt_types.h"
 
 namespace wsl {
 namespace thunk {

--- a/shared/include/d3dkmt_types.h
+++ b/shared/include/d3dkmt_types.h
@@ -45,7 +45,7 @@
 
 #include <cstdint>
 #include <ntstatus.h>
-#include "wddm_types.h"
+#include "shared/include/wddm_types.h"
 // windows wchar is 16bit, but linux is 32bit
 // seems libdxcore (not dxgkrnl.ko) convert thunk windows wchar to linux one
 // so only accept 32bit wchar args. note driver private data structure still

--- a/shared/include/device.h
+++ b/shared/include/device.h
@@ -1,5 +1,5 @@
-#ifndef _WSL_INC_WDDM_DEVICE_H_
-#define _WSL_INC_WDDM_DEVICE_H_
+#ifndef _WSL_SHARED_INC_DEVICE_H_
+#define _WSL_SHARED_INC_DEVICE_H_
 
 #include <memory>
 #include <vector>

--- a/shared/include/device.h
+++ b/shared/include/device.h
@@ -4,10 +4,10 @@
 #include <memory>
 #include <vector>
 
-#include "d3dkmt_types.h"
-#include "gpu_info.h"
-#include "status.h"
-#include "thunk_proxy/thunk_proxy.h"
+#include "shared/include/d3dkmt_types.h"
+#include "shared/include/gpu_info.h"
+#include "shared/include/status.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
 
 namespace wsl {
 namespace thunk {

--- a/shared/include/dxcore_loader.h
+++ b/shared/include/dxcore_loader.h
@@ -23,7 +23,7 @@
 #ifndef DXG_SHARED_DXCORE_LOADER_H
 #define DXG_SHARED_DXCORE_LOADER_H
 
-#include "d3dkmt_types.h"
+#include "shared/include/d3dkmt_types.h"
 #include <dlfcn.h>
 #include <mutex>
 

--- a/shared/include/lda_chain.h
+++ b/shared/include/lda_chain.h
@@ -43,11 +43,11 @@
 #ifndef _WSL_THUNK_INC_LDA_CHAIN_H_
 #define _WSL_THUNK_INC_LDA_CHAIN_H_
 
-#include "status.h"
-#include "constants.h"
-#include "utils.h"
-#include "d3dkmt_types.h"
-#include "thunk_proxy/thunk_proxy.h"
+#include "shared/include/status.h"
+#include "shared/include/constants.h"
+#include "shared/include/utils.h"
+#include "shared/include/d3dkmt_types.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
 #include <memory>
 #include <vector>
 

--- a/shared/include/platform.h
+++ b/shared/include/platform.h
@@ -43,8 +43,8 @@
 #ifndef _WSL_THUNK_INC_PLATFORM_H_
 #define _WSL_THUNK_INC_PLATFORM_H_
 
-#include "lda_chain.h"
-#include "utils.h"
+#include "shared/include/lda_chain.h"
+#include "shared/include/utils.h"
 #include <vector>
 
 namespace wsl {

--- a/shared/include/thunk_proxy/thunk_proxy.h
+++ b/shared/include/thunk_proxy/thunk_proxy.h
@@ -2,9 +2,9 @@
 #define SHARED_THUNK_PROXY_H
 
 #include <vector>
-#include "d3dkmt_types.h"
-#include "gpu_info.h"
-#include "status.h"
+#include "shared/include/d3dkmt_types.h"
+#include "shared/include/gpu_info.h"
+#include "shared/include/status.h"
 
 namespace thunk_proxy {
 

--- a/shared/include/thunks.h
+++ b/shared/include/thunks.h
@@ -43,10 +43,10 @@
 #ifndef SHARED_THUNKS_H
 #define SHARED_THUNKS_H
 
-#include "status.h"
-#include "d3dkmt_types.h"
-#include "dxcore_loader.h"
-#include "lda_chain.h"
+#include "shared/include/status.h"
+#include "shared/include/d3dkmt_types.h"
+#include "shared/include/dxcore_loader.h"
+#include "shared/include/lda_chain.h"
 
 namespace wsl {
 namespace thunk {

--- a/shared/src/device.cpp
+++ b/shared/src/device.cpp
@@ -1,7 +1,7 @@
-#include "thunks.h"
-#include "device.h"
-#include "lda_chain.h"
-#include "thunk_proxy/thunk_proxy.h"
+#include "shared/include/thunks.h"
+#include "shared/include/device.h"
+#include "shared/include/lda_chain.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
 #include <memory>
 
 using namespace std;

--- a/shared/src/dxcore_loader.cpp
+++ b/shared/src/dxcore_loader.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
  */
 
-#include "dxcore_loader.h"
+#include "shared/include/dxcore_loader.h"
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/shared/src/lda_chain.cpp
+++ b/shared/src/lda_chain.cpp
@@ -40,11 +40,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "device.h"
-#include "thunks.h"
-#include "lda_chain.h"
-#include "thunk_proxy/thunk_proxy.h"
-#include "constants.h"
+#include "shared/include/device.h"
+#include "shared/include/thunks.h"
+#include "shared/include/lda_chain.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
+#include "shared/include/constants.h"
 #include <algorithm>
 #include <memory>
 

--- a/shared/src/platform.cpp
+++ b/shared/src/platform.cpp
@@ -40,11 +40,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "constants.h"
-#include "thunks.h"
-#include "platform.h"
-#include "device.h"
-#include "thunk_proxy/thunk_proxy.h"
+#include "shared/include/constants.h"
+#include "shared/include/thunks.h"
+#include "shared/include/platform.h"
+#include "shared/include/device.h"
+#include "shared/include/thunk_proxy/thunk_proxy.h"
 #include <memory>
 #include <vector>
 

--- a/shared/src/status.cpp
+++ b/shared/src/status.cpp
@@ -40,7 +40,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "status.h"
+#include "shared/include/status.h"
 
 const char* ErrorCodeToString(const ErrorCode code) {
   switch (code) {

--- a/shared/src/utils.cpp
+++ b/shared/src/utils.cpp
@@ -1,4 +1,4 @@
-#include "utils.h"
+#include "shared/include/utils.h"
 
 namespace wsl {
 namespace thunk {

--- a/src/libdrm.cpp
+++ b/src/libdrm.cpp
@@ -41,7 +41,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <cstdint>
 
-#include "d3dkmt_types.h"
+#include "shared/include/d3dkmt_types.h"
 #include "impl/wddm/device.h"
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtGetAMDGPUDeviceHandle(

--- a/src/librocdxg.h
+++ b/src/librocdxg.h
@@ -33,9 +33,9 @@
 #include "hsakmt/hsakmt_drm.h"
 
 #include "impl/wddm/va_mgr.h"
-#include "d3dkmt_types.h"
+#include "shared/include/d3dkmt_types.h"
 #include "impl/wddm/device.h"
-#include "dxcore_loader.h"
+#include "shared/include/dxcore_loader.h"
 
 wsl::thunk::WDDMDevice* get_wddmdev(uint32_t node_id);
 uint32_t get_num_wddmdev();

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -38,7 +38,7 @@
 #include <unistd.h>
 #include <sys/sysinfo.h>
 
-#include "d3dkmt_types.h"
+#include "shared/include/d3dkmt_types.h"
 #include "impl/wddm/device.h"
 #include "util/utils.h"
 

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -49,11 +49,11 @@
 #include <linux/mman.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include "status.h"
-#include "d3dkmt_types.h"
+#include "shared/include/status.h"
+#include "shared/include/d3dkmt_types.h"
 #include "impl/wddm/device.h"
 #include "impl/wddm/queue.h"
-#include "utils.h"
+#include "shared/include/utils.h"
 
 namespace wsl {
 namespace thunk {


### PR DESCRIPTION
## Motivation

Headers under `shared/include/` were being included with bare filenames (e.g. `#include "device.h"`), which causes ambiguous resolution when multiple directories are on the include search path. A duplicate include guard in `shared/include/device.h` also caused silent redefinition issues. This PR fixes both problems to make the build deterministic and correct across all consumers (`librocdxg`, `amdsmi`, `shared/`).

## Technical Details

Two commits:

1. **`build: require shared headers via shared/include/ prefix`** ([c91908f2](https://github.com/yuliashi-amd/librocdxg/commit/c91908f2))
   - Changed all `#include "foo.h"` references to `shared/include/` headers to use the rooted form `#include "shared/include/foo.h"` across 23 files.
   - Updated `shared/CMakeLists.txt` to expose `shared/include/` as an explicit include directory so downstream targets resolve headers consistently.

2. **`shared: fix duplicate include guard`** ([5583e824](https://github.com/yuliashi-amd/librocdxg/commit/5583e824))
   - Fixed a duplicate include guard symbol in `shared/include/device.h` introduced by the path refactor.

## Test Plan

- Full build of `librocdxg` and `amdsmi` with both Debug and Release configurations:

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
