### PR TITLE
Handle WSL DXG teardown and missing VRAM segment info on Windows 10

### DIFF
--- a/include/impl/wddm/gpu_memory.h
+++ b/include/impl/wddm/gpu_memory.h
@@ -180,6 +180,11 @@ public:
   inline bool IsVirtual() const { return desc_.flags.is_virtual; }
   inline bool IsShared() const { return desc_.flags.is_shared; }
   inline bool IsExternal() const { return desc_.flags.is_external; }
+  inline bool IsImported() const {
+    return desc_.flags.is_imported_sys_memfd ||
+      desc_.flags.is_imported_vram_vmem ||
+      desc_.flags.is_imported_vram_ipc;
+  }
   inline bool IsVaAllocated() const { return desc_.flags.is_va_required; }
   inline bool IsBlitKernelObject() const { return desc_.flags.is_blit_kernel_object; }
 

--- a/src/wddm/gpu_memory.cpp
+++ b/src/wddm/gpu_memory.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include "impl/wddm/gpu_memory.h"
 #include "impl/wddm/device.h"
+#include "shared/include/platform.h"
 #include "util/utils.h"
 
 using namespace std;
@@ -46,14 +47,22 @@ GpuMemory::GpuMemory(WDDMDevice *device) : device_(device) {
 }
 
 GpuMemory::~GpuMemory() {
-  if (GpuAddress() != 0 &&
+  bool evicted_before_destroy = false;
+  if (Platform::instance().WddmVersion() < KMT_DRIVERVERSION_WDDM_3_0 &&
+      GpuAddress() != 0 &&
       alloc_handles_ptr_ != nullptr && !(NumChunks() == 1 && *alloc_handles_ptr_ == 0) &&
-      !IsVirtual() && !IsPhysicalOnly()) {
+      !IsVirtual() && !IsPhysicalOnly() && !IsImported()) {
     // In WSL, destroying a still-resident allocation can block in
     // dxgallocation_destroy while Hyper-V tears down the GPADL.
-    Evict();
+    ErrorCode code = Evict();
+    evicted_before_destroy = true;
+    if (code != ErrorCode::Success)
+      pr_err("Failed to evict allocation before destroy: %s\n",
+             ErrorCodeToString(code));
   }
   FreeGpuVirtualAddress(GpuAddress(), Size());
+  if (evicted_before_destroy && !device_->WaitOnPagingFenceFromCpu())
+    pr_err("Failed to wait on paging fence before destroy\n");
   FreePhysicalMemory();
   if (desc_.handle_ape_addr > 0)
     dxg_runtime->HandleApertureFree(desc_.handle_ape_addr);

--- a/src/wddm/gpu_memory.cpp
+++ b/src/wddm/gpu_memory.cpp
@@ -46,6 +46,13 @@ GpuMemory::GpuMemory(WDDMDevice *device) : device_(device) {
 }
 
 GpuMemory::~GpuMemory() {
+  if (GpuAddress() != 0 &&
+      alloc_handles_ptr_ != nullptr && !(NumChunks() == 1 && *alloc_handles_ptr_ == 0) &&
+      !IsVirtual() && !IsPhysicalOnly()) {
+    // In WSL, destroying a still-resident allocation can block in
+    // dxgallocation_destroy while Hyper-V tears down the GPADL.
+    Evict();
+  }
   FreeGpuVirtualAddress(GpuAddress(), Size());
   FreePhysicalMemory();
   if (desc_.handle_ape_addr > 0)


### PR DESCRIPTION
## Motivation

Windows 10 WSL2 does not currently work reliably with the `librocdxg` ROCm/HIP path. While Windows 11 / WDDM 3.1+ appears to be the intended supported environment, there are users on Windows 10 WSL2 systems where basic HIP device discovery and simple kernels can get close to working but currently fail on a few platform/runtime edges.

This PR is an MVP-style enablement patch for that Windows 10 WSL2 path. It addresses the two blockers observed during local testing:

- `VramAvail()` depends on WDDM segment type classification that is not available on Windows 10, causing bad `hipMemGetInfo()` behavior.
- Normal HIP process teardown can hang in the WSL DXG kernel path while destroying resident allocations.

The goal is not to declare Windows 10 WSL2 fully supported. The goal is to document and upstream the smallest changes that made basic ROCm/HIP workloads viable in this environment, and hopefully give AMD maintainers a concrete base to evaluate, refine, or replace with a more complete implementation.

## Technical Details

- `GpuMemory::~GpuMemory()` now evicts real resident allocations before freeing GPU VA / physical memory.
  - This gives normal user-mode teardown a chance to make the allocation non-resident before destruction.
  - The intent is to avoid hangs during WSL DXG allocation destruction.

- `WDDMDevice::GetSegmentId()` now accepts an optional `log_error` argument.
  - Existing callers keep the previous behavior by default.
  - `VramAvail()` uses the quiet path for the dGPU memory-segment lookup because missing segment classification can be an expected platform condition.

- `VramAvail()` now falls back to `LocalHeapSize()` for dGPU when the WDDM memory segment type is unavailable.
  - This avoids returning an error-like value through VRAM availability queries.
  - It provides a static fallback rather than live residency accounting.

Related discussion:

- https://github.com/ROCm/librocdxg/issues/22
- https://github.com/ROCm/librocdxg/issues/22#issuecomment-4323784066

## Test Plan

Tested in WSL2 with `HSA_ENABLE_DXG_DETECTION=1` and a locally rebuilt `librocdxg`.

Build:

```bash
cmake --build /root/rocdxg-build -j2
```

Runtime validation:

- `rocminfo` detects the GPU agent.
- Normal teardown probe using `hipGetDeviceCount()` exits cleanly.
- Vector-add HIP probe tested at:
  - 1 MiB + 4 bytes
  - 4 MiB
  - 64 MiB
- Repeated 4 MiB vector-add in 10 fresh processes without `wsl --shutdown`.
- `hipMemGetInfo()` before and after a 64 MiB allocation.
- Explicit `hipFree()` return checked in vector and allocation tests.

## Test Environment

- Host OS: Windows 10 IoT Enterprise LTSC 2021 / 21H2, build 19044
- WSL kernel: 6.6.114.1-microsoft-standard-WSL2
- GPU: AMD Radeon RX 9070 XT
- AMD driver: 32.0.23027.2005 / Adrenalin 26.2.2
- WSL distro: Ubuntu 24.04.4 LTS
- ROCm: 7.2.1
- ROCDXG package: rocdxg-roct 1.2.0
- librocdxg: /opt/rocm-7.2.1/lib/librocdxg.so.1.2.0

## Test Result

With this patch, basic HIP workloads became viable on the tested Windows 10 WSL2 system.

Passed:

- GPU discovery via `rocminfo`
- 1 MiB + 4 bytes vector-add
- 4 MiB vector-add
- 64 MiB vector-add
- 10 repeated fresh-process vector-add runs without `wsl --shutdown`
- `hipMemGetInfo()` before/after allocation
- explicit `hipFree()` path

Known limitation: abrupt process termination via `std::_Exit` can still bypass user-mode cleanup and leave teardown to the WSL/DXG kernel release path. This PR addresses normal ROCm/HIP cleanup, not forced process death.

`hipMemGetInfo()` now returns sane static VRAM values on Windows 10, but this fallback is not live residency accounting.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Disclosure

Codex assisted with the investigation, probing, and patch iteration. I reviewed the final diff and verified the test results before submitting.