### PR TITLE
add radeon 7600xt support

### DIFF
--- a/shared/src/utils.cpp
+++ b/shared/src/utils.cpp
@@ -11,6 +11,7 @@ const struct GfxipTable kGfxipTable[] = {
   { 0x744a, 11, 0, 0 },
   { 0x744b, 11, 0, 0 },
   { 0x7470, 11, 0, 1 },
+  { 0x7480, 11, 0, 2 },
   { 0x747E, 11, 0, 1 },
   { 0x7590, 12, 0, 0 },
   { 0x7550, 12, 0, 1 },
@@ -19,6 +20,7 @@ const struct GfxipTable kGfxipTable[] = {
   { 0x1586, 11, 5, 1 },
   { 0x1114, 11, 5, 2 },
   { 0x1900, 11, 0, 3 },
+  
 };
 
 const int kGfxipTableSize = sizeof(kGfxipTable) / sizeof(kGfxipTable[0]);


### PR DESCRIPTION
## Motivation

Add Rad 7600XT support

Partially resolves [this issue]( https://github.com/ROCm/librocdxg/issues/32)

## Technical Details

Added 0x7480 gfx1102 to util list

Following feature request suggestion[here](https://github.com/ROCm/ROCm/issues/6119)

## Test Plan

1. followed instructions build and install
2. build and run llama.cpp with HIP support
3. attempt to run llama.cpp with -ngl > 0 

## Test Result


rocminfo displays 
<img width="1078" height="449" alt="image" src="https://github.com/user-attachments/assets/26d6d95e-75ae-42c5-ae1a-df576c328865" />

when running llama.cpp with
```
./bin/llama-cli -hf Qwen/Qwen2.5-Coder-14B-Instruct-GGUF:Q6_K -ngl 35 --verbose
```
logs show layers are assigned to the GPU.
<img width="1484" height="585" alt="image" src="https://github.com/user-attachments/assets/cd621b2e-47fe-4af9-a46d-147084319613" />

Cleanly generated responses.
<img width="1001" height="533" alt="image" src="https://github.com/user-attachments/assets/a67a2f17-f5b6-4048-b7e7-4860510bf311" />



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.