### PR TITLE
wddm: VramAvail segment group query with per-segment fallback

### DIFF
--- a/include/impl/wddm/device.h
+++ b/include/impl/wddm/device.h
@@ -146,7 +146,7 @@ public:
   }
   uint32_t GetComputeEngine() { return shared_dev_->ComputeEngine(); }
 
-  uint64_t VramAvail();
+  ErrorCode VramAvail(uint64_t *avail);
 
   void GetClockCounters(uint64_t *gpu, uint64_t *cpu);
   uint32_t GetNumCpQueues() { return shared_dev_->NumCpQueues(); }
@@ -216,7 +216,8 @@ private:
   void InitCmdbufInfo(void);
 
   bool QuerySegmentInfo();
-  bool GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type, uint32_t &segment_id);
+  bool GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
+                    uint32_t &segment_id);
 
   D3DKMT_HANDLE adapter_;
   Device *shared_dev_ = nullptr;
@@ -230,7 +231,7 @@ private:
   uint32_t cmdbuf_aql_frame_size_;
   static const uint32_t cmdbuf_aql_frame_num_;
   uint32_t node_id_;
-  std::vector<struct SegmentInfo> segment_infos_;
+  std::vector<SegmentInfo> segment_infos_;
   //CmdUtil cmd_util;
 };
 

--- a/shared/include/platform.h
+++ b/shared/include/platform.h
@@ -68,10 +68,13 @@ public:
 
   size_t GetLdaChainCount() const { return lda_chain_count_; }
   LdaChain *GetLdaChain(size_t index) const { return lda_chain_list_[index]; }
+
+  D3DKMT_DRIVERVERSION WddmVersion() const { return wddm_version_; }
 private:
   ErrorCode initProperties();
   ErrorCode reQueryDevices();
   ErrorCode queryLinkedDevicesInLdaChain(const D3DKMT_ADAPTERINFO &adapterInfo);
+  void queryWddmVersion(D3DKMT_HANDLE adapter);
 
   Platform() = default;
   DISABLE_COPY_AND_ASSIGN(Platform);
@@ -79,6 +82,7 @@ private:
   LdaChain *lda_chain_list_[MaxDevices];
   u32 lda_chain_count_ = 0;
   std::vector<Device *> devices_;
+  D3DKMT_DRIVERVERSION wddm_version_ = static_cast<D3DKMT_DRIVERVERSION>(0);
 };
 
 } // namespace thunk

--- a/shared/src/platform.cpp
+++ b/shared/src/platform.cpp
@@ -110,6 +110,9 @@ ErrorCode Platform::reQueryDevices() {
   if (code = d3dthunk::EnumAdapters(&args); code != ErrorCode::Success)
     return code;
 
+  if (args.NumAdapters > 0)
+    queryWddmVersion(infos[0].hAdapter);
+
   for (u32 i = 0; i < args.NumAdapters; ++i)
     code = queryLinkedDevicesInLdaChain(args.pAdapters[i]);
 
@@ -186,6 +189,19 @@ ErrorCode Platform::queryLinkedDevicesInLdaChain(
   }
 
   return code;
+}
+
+void Platform::queryWddmVersion(D3DKMT_HANDLE adapter) {
+  D3DKMT_DRIVERVERSION version = static_cast<D3DKMT_DRIVERVERSION>(0);
+  d3dthunk::QueryAdapterInfoArgs queryInfo{};
+
+  queryInfo.hAdapter = adapter;
+  queryInfo.Type = KMTQAITYPE_DRIVERVERSION;
+  queryInfo.pPrivateDriverData = &version;
+  queryInfo.PrivateDriverDataSize = sizeof(version);
+
+  if (d3dthunk::QueryAdapterInfo(&queryInfo) == ErrorCode::Success)
+    wddm_version_ = version;
 }
 
 } // namespace thunk

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -395,7 +395,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtAvailableMemory(HSAuint32 Node,
   if (!dev)
     return HSAKMT_STATUS_ERROR;
 
-  *AvailableBytes = dev->VramAvail();
+  if (dev->VramAvail(AvailableBytes) != ErrorCode::Success)
+    return HSAKMT_STATUS_ERROR;
   return HSAKMT_STATUS_SUCCESS;
 }
 

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -119,7 +119,7 @@ bool WDDMDevice::QuerySegmentInfo()
       return false;
     }
 
-    auto& seg = segQuery.QueryResult.SegmentInformation;
+    const auto& seg = segQuery.QueryResult.SegmentInformation;
 
     SegmentInfo info;
     info.segment_id = i;
@@ -129,80 +129,190 @@ bool WDDMDevice::QuerySegmentInfo()
     info.commit_limit = seg.CommitLimit;
 
     segment_infos_.push_back(info);
+
+    pr_info("segment %u: type %u system_memory %u aperture %u "
+            "commit_limit %" PRIu64 "MB bytes_resident %" PRIu64
+            "MB bytes_committed %" PRIu64 "MB\n",
+            i, info.segment_type, info.system_memory ? 1u : 0u,
+            info.aperture ? 1u : 0u, info.commit_limit >> 20,
+            seg.BytesResident >> 20, seg.BytesCommitted >> 20);
   }
 
   return true;
 }
 
 bool WDDMDevice::GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
-                              uint32_t &segment_id)
-{
+                              uint32_t &segment_id) {
   for (const auto& seg_info : segment_infos_) {
     if (seg_info.segment_type == segment_type) {
       segment_id = seg_info.segment_id;
       return true;
     }
   }
-  pr_err("Failed to get segment id for type %u\n", segment_type);
+  pr_warn("Failed to get segment id for type %u\n", segment_type);
   return false;
 }
 
 /*Local heap(dedicated GPU memory) includes visiable heap and invisiable heap.
  *Non local heap refers to shared GPU memory and it is sytem memory.
  */
-uint64_t WDDMDevice::VramAvail(void) {
-  D3DKMT_QUERYSTATISTICS stats;
-  ErrorCode ret;
-  uint64_t usedVis = 0;
-  uint64_t usedInv = 0;
-  uint64_t usedNonLocal = 0;
-  uint32_t segmentId = 0;
+ErrorCode WDDMDevice::VramAvail(uint64_t *avail) {
+  if (!avail)
+    return ErrorCode::InvalidPointer;
+
+  *avail = 0;
 
   // wait fence complete
   uint64_t value = page_fence_value_.load();
   if (!CpuWait(&page_syncobj_, &value, 1, false))
-    return HSA_STATUS_ERROR;
+    return ErrorCode::Unknown;
 
-  // local cpu-visible memory
-  if (!GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_MEMORY, segmentId))
-    return HSA_STATUS_ERROR;
+  // Segment group usage query requires WDDM 3.1+.
+  bool seg_fallback =
+      Platform::instance().WddmVersion() < KMT_DRIVERVERSION_WDDM_3_1;
+  bool segment_info_queried = false;
+  bool have_segment_info = false;
 
-  memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
-  stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-  stats.AdapterLuid = GetLuid();
-  stats.QuerySegment.SegmentId = segmentId;
-  ret = dx::QueryStatistics(&stats);
-  if (ret == ErrorCode::Success)
-    usedVis = stats.QueryResult.SegmentInformation.BytesResident;
+  auto ensure_segment_info = [&]() -> bool {
+    if (segment_info_queried)
+      return have_segment_info;
+    segment_info_queried = true;
+    have_segment_info = QuerySegmentInfo();
+    return have_segment_info;
+  };
 
-  // local invisible memory
-  if (LocalInvisibleHeapSize()) {
-    segmentId++;
-    memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
-    stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-    stats.AdapterLuid = GetLuid();
-    stats.QuerySegment.SegmentId = segmentId;
-    ret = dx::QueryStatistics(&stats);
-    if (ret == ErrorCode::Success)
-      usedInv = stats.QueryResult.SegmentInformation.BytesResident;
+  auto query_segment_usage = [this](uint32_t segment_id,
+                                    uint64_t *bytes_resident) -> ErrorCode {
+    D3DKMT_QUERYSTATISTICS seg_stats{};
+    seg_stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
+    seg_stats.AdapterLuid = GetLuid();
+    seg_stats.QuerySegment.SegmentId = segment_id;
+
+    ErrorCode seg_ret = dx::QueryStatistics(&seg_stats);
+    if (seg_ret != ErrorCode::Success) {
+      pr_err("Segment %u usage query failed (%d)\n", segment_id,
+             static_cast<int>(seg_ret));
+      *bytes_resident = 0;
+      return seg_ret;
+    }
+
+    *bytes_resident = seg_stats.QueryResult.SegmentInformation.BytesResident;
+    return ErrorCode::Success;
+  };
+
+  auto query_segment_group_usage = [this](uint32_t segment_group,
+                                          const char *name,
+                                          uint64_t *bytes_allocated) -> ErrorCode {
+    D3DKMT_QUERYSTATISTICS sg_stats{};
+    sg_stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT_GROUP_USAGE;
+    sg_stats.AdapterLuid = GetLuid();
+    sg_stats.QuerySegmentGroupUsage.PhysicalAdapterIndex = 0;
+    sg_stats.QuerySegmentGroupUsage.SegmentGroup = segment_group;
+
+    ErrorCode sg_ret = dx::QueryStatistics(&sg_stats);
+    if (sg_ret != ErrorCode::Success) {
+      *bytes_allocated = 0;
+      return sg_ret;
+    }
+
+    const auto &usage = sg_stats.QueryResult.SegmentGroupUsageInformation;
+    *bytes_allocated = usage.AllocatedBytes;
+    pr_info("%s segment group usage: allocated %" PRIu64 "MB, free %" PRIu64
+            "MB, zero %" PRIu64 "MB, modified %" PRIu64 "MB, standby %" PRIu64
+            "MB\n",
+            name, usage.AllocatedBytes >> 20, usage.FreeBytes >> 20,
+            usage.ZeroBytes >> 20, usage.ModifiedBytes >> 20,
+            usage.StandbyBytes >> 20);
+    return ErrorCode::Success;
+  };
+
+  auto resolve_segment_id =
+      [&](D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
+          uint32_t hardcoded_id) -> uint32_t {
+    uint32_t segment_id = hardcoded_id;
+    if (ensure_segment_info() && GetSegmentId(segment_type, segment_id))
+      return segment_id;
+
+    pr_warn("[VramAvail] segment type %u not found, using hardcoded segment %u\n",
+            segment_type, hardcoded_id);
+    return hardcoded_id;
+  };
+
+  auto local_used = [&](uint64_t *used) -> ErrorCode {
+    if (!used)
+      return ErrorCode::InvalidPointer;
+
+    *used = 0;
+    if (!seg_fallback &&
+        query_segment_group_usage(D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL, "Local",
+                                  used) == ErrorCode::Success)
+      return ErrorCode::Success;
+
+    if (!seg_fallback) {
+      pr_warn("Local segment group usage query failed, falling back to segment query\n");
+      seg_fallback = true;
+    }
+
+    uint32_t segment_id =
+        resolve_segment_id(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_MEMORY, 0);
+
+    uint64_t vis = 0;
+    ErrorCode ret = query_segment_usage(segment_id, &vis);
+    if (ret != ErrorCode::Success)
+      return ret;
+    *used = vis;
+
+    if (LocalInvisibleHeapSize()) {
+      segment_id++;
+      uint64_t inv = 0;
+      ret = query_segment_usage(segment_id, &inv);
+      if (ret != ErrorCode::Success)
+        return ret;
+      *used += inv;
+    }
+    return ErrorCode::Success;
+  };
+
+  auto nonlocal_used = [&](uint64_t *used) -> ErrorCode {
+    if (!used)
+      return ErrorCode::InvalidPointer;
+
+    *used = 0;
+    if (!seg_fallback) {
+      if (query_segment_group_usage(D3DKMT_MEMORY_SEGMENT_GROUP_NON_LOCAL,
+                                    "Non-local", used) == ErrorCode::Success)
+        return ErrorCode::Success;
+
+      pr_warn("Non-local segment group usage query failed, falling back to segment query\n");
+    }
+
+    const uint32_t hardcoded_id = LocalInvisibleHeapSize() ? 4 : 3;
+    const uint32_t segment_id =
+        resolve_segment_id(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_SYSMEM,
+                           hardcoded_id);
+    return query_segment_usage(segment_id, used);
+  };
+
+  uint64_t usedLocal = 0;
+  ErrorCode ret = local_used(&usedLocal);
+  if (ret != ErrorCode::Success)
+    return ret;
+
+  if (IsDgpu()) {
+    const uint64_t total = LocalHeapSize();
+    *avail = usedLocal >= total ? 0 : total - usedLocal;
+    return ErrorCode::Success;
   }
 
-  if (IsDgpu())
-    return LocalHeapSize() - usedVis - usedInv;
+  uint64_t usedNonLocal = 0;
+  ret = nonlocal_used(&usedNonLocal);
+  if (ret != ErrorCode::Success)
+    return ret;
 
-  // APU - NonLocal memory
-  if (!GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_SYSMEM, segmentId))
-    return HSA_STATUS_ERROR;
-
-  memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
-  stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-  stats.AdapterLuid = GetLuid();
-  stats.QuerySegment.SegmentId = segmentId;
-  ret = dx::QueryStatistics(&stats);
-  if (ret == ErrorCode::Success)
-    usedNonLocal = stats.QueryResult.SegmentInformation.BytesResident;
-
-  return LocalHeapSize() + NonLocalHeapSize() - usedVis - usedInv - usedNonLocal;
+  const uint64_t total = LocalHeapSize() + NonLocalHeapSize();
+  const uint64_t used = usedLocal + usedNonLocal;
+  *avail = used >= total ? 0 : total - used;
+  return ErrorCode::Success;
 }
 
 bool WDDMDevice::CreatePagingQueue(void) {

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -74,7 +74,12 @@ WDDMDevice::WDDMDevice(Device *shared_dev,
   SetPowerOptimization(false);
   CreatePagingQueue();
   InitCmdbufInfo();
-  QuerySegmentInfo();
+
+  unsigned ver = static_cast<unsigned>(Platform::instance().WddmVersion());
+  if (ver)
+    pr_info("WDDM version %u.%u\n", ver / 1000, (ver % 1000) / 100);
+  else
+    pr_info("WDDM version: unknown\n");
 }
 
 WDDMDevice::~WDDMDevice() {


### PR DESCRIPTION
## Motivation

Prefer D3DKMT_QUERYSTATISTICS_SEGMENT_GROUP_USAGE for local / non-local VRAM accounting. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
