### PR TITLE
Add gfx11.5.3 to supported device list

### DIFF
--- a/shared/src/utils.cpp
+++ b/shared/src/utils.cpp
@@ -29,6 +29,7 @@ static const struct GfxipTable kGfxipTable[] = {
   { 0x1586, 11, 5, 1 },
   { 0x1114, 11, 5, 2 },
   { 0x1900, 11, 0, 3 },
+  { 0x1902, 11, 5, 3 },
 };
 
 const int kGfxipTableSize = sizeof(kGfxipTable) / sizeof(kGfxipTable[0]);


### PR DESCRIPTION
## Motivation

Add support for new GFX IP variant so that GPUs with this device ID is recognized by QueryAdapterSupported() and can be used on WSL.

## Technical Details

Add PCI device ID 0x1902(GFX 11.5.3)  to kGfxipTable.

## Test Result

Verified that QueryAdapterSupported() correctly returns true for the new device ID on the respective hardware.
