### PR TITLE
cmake: share PACKAGE_VERSION_SUFFIX for deb package versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,6 @@ if ( NOT DEFINED PACKAGE_VERSION OR "${PACKAGE_VERSION}" STREQUAL "" )
 endif ()
 set ( ROCDXG_VERSION "${PACKAGE_VERSION}" )
 
-# Optional pre-release suffix (e.g. -DROCDXG_VERSION_PRERELEASE=rc1 produces 1.1.2~rc1).
-# Leave empty for a normal release build (1.1.2).
-set ( ROCDXG_VERSION_PRERELEASE "" CACHE STRING "Pre-release suffix appended to package version (e.g. rc1). Empty for release." )
-
 project ( ${ROCDXG_TARGET} VERSION ${ROCDXG_VERSION} )
 # Project/version initialized; expose version to code via target defs below
 
@@ -70,6 +66,7 @@ set ( CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE STRING "Default install
 
 ## Include common cmake modules
 include ( utils )
+include ( package_version )
 include ( GNUInstallDirs )
 
 ## Setup the package version.
@@ -303,12 +300,7 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/DEBIAN/conffiles"
 
 # Prepare final version for the CPACK use
 set(PACKAGE_VERSION_STR "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
-if ( NOT "${ROCDXG_VERSION_PRERELEASE}" STREQUAL "" )
-    string ( TOLOWER "${ROCDXG_VERSION_PRERELEASE}" _ROCDXG_VERSION_PRERELEASE_LC )
-    # Use Debian's '~' separator so pre-releases sort BEFORE the final release.
-    set(PACKAGE_VERSION_STR "${PACKAGE_VERSION_STR}~${_ROCDXG_VERSION_PRERELEASE_LC}")
-    message(STATUS "Building pre-release version: ${PACKAGE_VERSION_STR}")
-endif()
+apply_package_version_suffix("${PACKAGE_VERSION_STR}" PACKAGE_VERSION_STR)
 set(CPACK_PACKAGE_VERSION "${PACKAGE_VERSION_STR}")
 
 # Debian package specific variables

--- a/amdsmi/CMakeLists.txt
+++ b/amdsmi/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/" CACHE INTERNA
 ## Include common cmake modules
 include(utils)
 include(help_package)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/package_version.cmake)
 find_package(PkgConfig)
 
 generic_add_rocm()
@@ -62,16 +63,16 @@ if(NOT DEFINED PACKAGE_VERSION OR "${PACKAGE_VERSION}" STREQUAL "")
     string(STRIP "${PACKAGE_VERSION}" PACKAGE_VERSION)
 endif()
 set(AMDSMI_PACKAGE_VERSION "${PACKAGE_VERSION}")
-set(CPACK_PACKAGE_VERSION "${AMDSMI_PACKAGE_VERSION}")
 
 # Parse AMDSMI_PACKAGE_VERSION as the single source of truth
 get_package_version_number(${AMDSMI_PACKAGE_VERSION})
+set(AMDSMI_PACKAGE_VERSION_BASE "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
 message("Package version: ${AMDSMI_PACKAGE_VERSION}")
 set(${AMD_SMI_LIBS_TARGET}_VERSION_MAJOR "${CPACK_PACKAGE_VERSION_MAJOR}")
 set(${AMD_SMI_LIBS_TARGET}_VERSION_MINOR "${CPACK_PACKAGE_VERSION_MINOR}")
 set(${AMD_SMI_LIBS_TARGET}_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}")
 # Used by configure_file() in py-interface and amdsmi_cli for _version.py, setup.py, pyproject.toml
-set(${AMD_SMI_LIBS_TARGET}_VERSION_STRING "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+set(${AMD_SMI_LIBS_TARGET}_VERSION_STRING "${AMDSMI_PACKAGE_VERSION_BASE}")
 
 # The following default version values should be updated as appropriate for
 # ABI breaks (update MAJOR and MINOR), and ABI/API additions (update MINOR).
@@ -199,7 +200,7 @@ configure_package_config_file(
     PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_BINDIR)
 
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/amd_smi-config-version.cmake
-                                 VERSION "${CPACK_PACKAGE_VERSION}" COMPATIBILITY SameMajorVersion)
+                                 VERSION "${AMDSMI_PACKAGE_VERSION_BASE}" COMPATIBILITY SameMajorVersion)
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/amd_smi-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/amd_smi-config-version.cmake
@@ -333,6 +334,8 @@ endif()
 #Set the names now using CPACK utility
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+
+apply_package_version_suffix("${AMDSMI_PACKAGE_VERSION_BASE}" CPACK_PACKAGE_VERSION)
 
 # Configure Lintian Specific Package Data
 configure_pkg( ${CPACK_PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL})

--- a/cmake_modules/package_version.cmake
+++ b/cmake_modules/package_version.cmake
@@ -1,0 +1,21 @@
+################################################################################
+##
+## Shared Debian package version suffix for rocdxg and amdsmi.
+##
+## Example: -DPACKAGE_VERSION_SUFFIX=115  -> 1.1.2~115
+##          -DPACKAGE_VERSION_SUFFIX=rc2  -> 1.1.2~rc2
+##
+################################################################################
+
+set(PACKAGE_VERSION_SUFFIX "" CACHE STRING
+    "Optional suffix for Debian package version (e.g. 115, rc2). Empty for release.")
+
+function(apply_package_version_suffix BASE_VERSION OUT_VAR)
+    set(_version "${BASE_VERSION}")
+    if(NOT "${PACKAGE_VERSION_SUFFIX}" STREQUAL "")
+        string(TOLOWER "${PACKAGE_VERSION_SUFFIX}" _suffix_lc)
+        set(_version "${_version}~${_suffix_lc}")
+        message(STATUS "Debian package version: ${_version}")
+    endif()
+    set(${OUT_VAR} "${_version}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Replace ROCDXG_VERSION_PRERELEASE with a common PACKAGE_VERSION_SUFFIX and apply_package_version_suffix() helper used by rocdxg and amdsmi.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
