### PR TITLE
shared/wddm: move VRAM availability query into Device

### DIFF
--- a/include/impl/wddm/device.h
+++ b/include/impl/wddm/device.h
@@ -48,7 +48,6 @@
 
 #include <atomic>
 #include <memory>
-#include <vector>
 
 #include "shared/include/d3dkmt_types.h"
 #include "shared/include/device.h"
@@ -72,18 +71,6 @@ class WDDMQueue;
 #define END_NON_CANONICAL_ADDR (~0UL - (1UL << 47))
 #define IS_OVERLAPPING(start1, size1, start2, size2) \
   ((start1 < (start2 + size2)) && (start2 < (start1 + size1)))
-
-struct SegmentInfo {
-  uint32_t segment_id;
-  uint32_t segment_type;    // 0=aperture, 1=gpu memory, 2=system memory
-  bool aperture;
-  bool system_memory;
-  uint64_t commit_limit;
-
-  SegmentInfo()
-      : segment_id(0), segment_type(0), aperture(false),
-        system_memory(false), commit_limit(0) {}
-};
 
 class WDDMDevice {
 public:
@@ -215,10 +202,6 @@ private:
   void SetPowerOptimization(bool restore);
   void InitCmdbufInfo(void);
 
-  bool QuerySegmentInfo();
-  bool GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
-                    uint32_t &segment_id);
-
   D3DKMT_HANDLE adapter_;
   Device *shared_dev_ = nullptr;
 
@@ -231,7 +214,6 @@ private:
   uint32_t cmdbuf_aql_frame_size_;
   static const uint32_t cmdbuf_aql_frame_num_;
   uint32_t node_id_;
-  std::vector<SegmentInfo> segment_infos_;
   //CmdUtil cmd_util;
 };
 

--- a/shared/include/device.h
+++ b/shared/include/device.h
@@ -59,6 +59,12 @@ public:
   // Query resident bytes for a VRAM segment bucket (see VramSegmentKind).
   ErrorCode QueryVramSegmentUsage(VramSegmentKind kind, uint64_t *usage) const;
 
+  // Total VRAM reported to upper stacks.
+  uint64_t VramTotal() const;
+
+  // WDDM segment usage for VramTotal() buckets.
+  ErrorCode QueryVramUsage(uint64_t *usage_bytes) const;
+
   ErrorCode QueryPowerInfo(PowerInfo *info) const;
 
   ErrorCode QueryTempMetric(uint32_t sensor_type, uint32_t metric,

--- a/shared/include/device.h
+++ b/shared/include/device.h
@@ -1,6 +1,7 @@
 #ifndef _WSL_SHARED_INC_DEVICE_H_
 #define _WSL_SHARED_INC_DEVICE_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -13,6 +14,20 @@ namespace wsl {
 namespace thunk {
 
 constexpr gpusize PageSize = 0x1000u;
+
+// WDDM memory segment buckets used for VRAM availability accounting.
+enum class VramSegmentKind : uint8_t {
+  kFb,        // local visible (framebuffer)
+  kInvFb,     // local invisible
+  kLocal,     // kFb + kInvFb (local heap)
+  kNonLocal,  // shared system memory segment
+};
+
+struct VramSegmentIds {
+  uint32_t fb = 0;
+  uint32_t inv_fb = 1;
+  uint32_t non_local = 3;
+};
 
 class Platform;
 class LdaChain;
@@ -39,8 +54,10 @@ public:
 
   ErrorCode QueryVBiosInfo(VBiosInfo *info) const;
 
-  // Called once after creation to pre-fetch sensor limits.
   ErrorCode Init();
+
+  // Query resident bytes for a VRAM segment bucket (see VramSegmentKind).
+  ErrorCode QueryVramSegmentUsage(VramSegmentKind kind, uint64_t *usage) const;
 
   ErrorCode QueryPowerInfo(PowerInfo *info) const;
 
@@ -137,9 +154,12 @@ private:
   Device(Platform *platform, LdaChain *lda_chain, u32 chainIndex,
          std::unique_ptr<thunk_proxy::DeviceContext> device_ctx);
 
+  ErrorCode InitSegmentIds();
+
   std::unique_ptr<thunk_proxy::DeviceContext> device_ctx_;
   LdaChain *const lda_chain_ = nullptr;
   const u32       chain_index_ = 0;
+  VramSegmentIds segment_ids_{};
 };
 
 } // namespace thunk

--- a/shared/src/device.cpp
+++ b/shared/src/device.cpp
@@ -265,6 +265,33 @@ ErrorCode Device::QueryVramSegmentUsage(VramSegmentKind kind,
   return QuerySegmentBytesResident(luid, segment_id, usage);
 }
 
+uint64_t Device::VramTotal() const {
+  uint64_t total = LocalVisibleHeapSize() + LocalInvisibleHeapSize();
+  if (!IsDgpu())
+    total += NonLocalHeapSize();
+  return total;
+}
+
+ErrorCode Device::QueryVramUsage(uint64_t *usage_bytes) const {
+  if (!usage_bytes)
+    return ErrorCode::InvalidPointer;
+
+  ErrorCode ret = QueryVramSegmentUsage(VramSegmentKind::kLocal, usage_bytes);
+  if (ret != ErrorCode::Success)
+    return ret;
+
+  if (IsDgpu())
+    return ErrorCode::Success;
+
+  uint64_t used_non_local = 0;
+  ret = QueryVramSegmentUsage(VramSegmentKind::kNonLocal, &used_non_local);
+  if (ret != ErrorCode::Success)
+    return ret;
+
+  *usage_bytes += used_non_local;
+  return ErrorCode::Success;
+}
+
 ErrorCode Device::QueryPowerInfo(PowerInfo *info) const {
   return device_ctx_->QueryPowerInfo(info);
 }

--- a/shared/src/device.cpp
+++ b/shared/src/device.cpp
@@ -1,13 +1,115 @@
 #include "shared/include/thunks.h"
 #include "shared/include/device.h"
 #include "shared/include/lda_chain.h"
+#include "shared/include/platform.h"
 #include "shared/include/thunk_proxy/thunk_proxy.h"
+#include <limits>
 #include <memory>
+#include <vector>
 
 using namespace std;
 
 namespace wsl {
 namespace thunk {
+
+namespace dx = wsl::thunk::d3dthunk;
+
+namespace {
+
+constexpr uint32_t kInvalidSegmentId = std::numeric_limits<uint32_t>::max();
+
+struct SegmentInfo {
+  uint32_t segment_id = 0;
+  uint32_t segment_type = 0;
+};
+
+ErrorCode QueryAllSegments(LUID luid, std::vector<SegmentInfo> *segments) {
+  if (!segments)
+    return ErrorCode::InvalidPointer;
+
+  segments->clear();
+
+  D3DKMT_QUERYSTATISTICS adapter_query{};
+  adapter_query.Type = D3DKMT_QUERYSTATISTICS_ADAPTER;
+  adapter_query.AdapterLuid = luid;
+
+  ErrorCode ret = dx::QueryStatistics(&adapter_query);
+  if (ret != ErrorCode::Success)
+    return ret;
+
+  const uint32_t segment_count =
+      adapter_query.QueryResult.AdapterInformation.NbSegments;
+
+  for (uint32_t i = 0; i < segment_count; i++) {
+    D3DKMT_QUERYSTATISTICS seg_query{};
+    seg_query.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
+    seg_query.AdapterLuid = luid;
+    seg_query.QuerySegment.SegmentId = i;
+
+    ret = dx::QueryStatistics(&seg_query);
+    if (ret != ErrorCode::Success)
+      return ret;
+
+    const auto &seg = seg_query.QueryResult.SegmentInformation;
+    SegmentInfo info;
+    info.segment_id = i;
+    info.segment_type = seg.SegmentProperties.SegmentType;
+    segments->push_back(info);
+  }
+
+  return ErrorCode::Success;
+}
+
+bool ResolveSegmentId(const std::vector<SegmentInfo> &segments,
+                      D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
+                      uint32_t default_id, uint32_t *segment_id) {
+  for (const auto &seg : segments) {
+    if (seg.segment_type == segment_type) {
+      *segment_id = seg.segment_id;
+      return true;
+    }
+  }
+  *segment_id = default_id;
+  return false;
+}
+
+ErrorCode QuerySegmentGroupUsage(LUID luid, uint32_t segment_group,
+                                 uint64_t *bytes_allocated) {
+  D3DKMT_QUERYSTATISTICS stats{};
+  stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT_GROUP_USAGE;
+  stats.AdapterLuid = luid;
+  stats.QuerySegmentGroupUsage.PhysicalAdapterIndex = 0;
+  stats.QuerySegmentGroupUsage.SegmentGroup = segment_group;
+
+  const ErrorCode ret = dx::QueryStatistics(&stats);
+  if (ret != ErrorCode::Success) {
+    *bytes_allocated = 0;
+    return ret;
+  }
+
+  *bytes_allocated =
+      stats.QueryResult.SegmentGroupUsageInformation.AllocatedBytes;
+  return ErrorCode::Success;
+}
+
+ErrorCode QuerySegmentBytesResident(LUID luid, uint32_t segment_id,
+                                    uint64_t *bytes_resident) {
+  D3DKMT_QUERYSTATISTICS stats{};
+  stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
+  stats.AdapterLuid = luid;
+  stats.QuerySegment.SegmentId = segment_id;
+
+  const ErrorCode ret = dx::QueryStatistics(&stats);
+  if (ret != ErrorCode::Success) {
+    *bytes_resident = 0;
+    return ret;
+  }
+
+  *bytes_resident = stats.QueryResult.SegmentInformation.BytesResident;
+  return ErrorCode::Success;
+}
+
+} // namespace
 
 Device::Device(Platform *platform, LdaChain *lda_chain, u32 chainIndex,
                std::unique_ptr<thunk_proxy::DeviceContext> device_ctx)
@@ -63,7 +165,104 @@ ErrorCode Device::QueryVBiosInfo(VBiosInfo *info) const {
 }
 
 ErrorCode Device::Init() {
-  return device_ctx_->Init();
+  ErrorCode ret = device_ctx_->Init();
+  if (ret != ErrorCode::Success)
+    return ret;
+  return InitSegmentIds();
+}
+
+ErrorCode Device::InitSegmentIds() {
+  // Default to hardcoded segment ids; these act as fallbacks when the
+  // runtime segment query is unavailable or fails.
+  segment_ids_.fb = 0;
+  segment_ids_.inv_fb = LocalInvisibleHeapSize() ? 1 : kInvalidSegmentId;
+  segment_ids_.non_local = LocalInvisibleHeapSize() ? 4 : 3;
+
+  if (Platform::instance().WddmVersion() >= KMT_DRIVERVERSION_WDDM_3_1) {
+    const LUID luid = AdapterLuid();
+    std::vector<SegmentInfo> segments;
+    if (QueryAllSegments(luid, &segments) != ErrorCode::Success) {
+      // Keep hardcoded fallback ids
+      return ErrorCode::Success;
+    }
+
+    ResolveSegmentId(segments, D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_MEMORY, segment_ids_.fb,
+                    &segment_ids_.fb);
+
+    if (LocalInvisibleHeapSize())
+      segment_ids_.inv_fb = segment_ids_.fb + 1;
+
+    ResolveSegmentId(segments, D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_SYSMEM,
+                    segment_ids_.non_local, &segment_ids_.non_local);
+  }
+
+  return ErrorCode::Success;
+}
+
+ErrorCode Device::QueryVramSegmentUsage(VramSegmentKind kind,
+                                        uint64_t *usage) const {
+  if (!usage)
+    return ErrorCode::InvalidPointer;
+
+  *usage = 0;
+
+  if (kind == VramSegmentKind::kInvFb &&
+      segment_ids_.inv_fb == kInvalidSegmentId)
+    return ErrorCode::Success;
+
+  const LUID luid = AdapterLuid();
+  const bool seg_group_supported =
+      Platform::instance().WddmVersion() >= KMT_DRIVERVERSION_WDDM_3_1;
+
+  if (kind == VramSegmentKind::kLocal && seg_group_supported) {
+    ErrorCode ret = QuerySegmentGroupUsage(
+        luid, D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL, usage);
+    if (ret == ErrorCode::Success)
+      return ErrorCode::Success;
+  }
+
+  if (kind == VramSegmentKind::kNonLocal && seg_group_supported) {
+    ErrorCode ret = QuerySegmentGroupUsage(
+        luid, D3DKMT_MEMORY_SEGMENT_GROUP_NON_LOCAL, usage);
+    if (ret == ErrorCode::Success)
+      return ErrorCode::Success;
+  }
+
+  if (kind == VramSegmentKind::kLocal) {
+    uint64_t fb = 0;
+    ErrorCode ret =
+        QuerySegmentBytesResident(luid, segment_ids_.fb, &fb);
+    if (ret != ErrorCode::Success)
+      return ret;
+
+    *usage = fb;
+    if (segment_ids_.inv_fb == kInvalidSegmentId)
+      return ErrorCode::Success;
+
+    uint64_t inv = 0;
+    ret = QuerySegmentBytesResident(luid, segment_ids_.inv_fb, &inv);
+    if (ret != ErrorCode::Success)
+      return ret;
+    *usage += inv;
+    return ErrorCode::Success;
+  }
+
+  uint32_t segment_id = 0;
+  switch (kind) {
+  case VramSegmentKind::kFb:
+    segment_id = segment_ids_.fb;
+    break;
+  case VramSegmentKind::kInvFb:
+    segment_id = segment_ids_.inv_fb;
+    break;
+  case VramSegmentKind::kNonLocal:
+    segment_id = segment_ids_.non_local;
+    break;
+  default:
+    return ErrorCode::InvalidParams;
+  }
+
+  return QuerySegmentBytesResident(luid, segment_id, usage);
 }
 
 ErrorCode Device::QueryPowerInfo(PowerInfo *info) const {

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -40,9 +40,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <cinttypes>
-#include <bitset>
-
 #include <sys/mman.h>
 #include <sys/sysinfo.h>
 #include <sys/stat.h>
@@ -87,72 +84,6 @@ WDDMDevice::~WDDMDevice() {
   SetPowerOptimization(true);
 }
 
-bool WDDMDevice::QuerySegmentInfo()
-{
-  uint32_t segmentCount = 0;
-  segment_infos_.clear();
-
-  // Get the number of segments
-  D3DKMT_QUERYSTATISTICS adapterQuery = {};
-  adapterQuery.Type = D3DKMT_QUERYSTATISTICS_ADAPTER;
-  adapterQuery.AdapterLuid = GetLuid();
-
-  ErrorCode ret = dx::QueryStatistics(&adapterQuery);
-  if (ret == ErrorCode::Success) {
-    segmentCount = adapterQuery.QueryResult.AdapterInformation.NbSegments;
-    pr_debug("Total Segments: %u\n", segmentCount);
-  } else {
-    pr_err("Failed to query adapter info\n");
-    return false;
-  }
-
-  for (uint32_t i = 0; i < segmentCount; i++) {
-
-    D3DKMT_QUERYSTATISTICS segQuery = {};
-    segQuery.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-    segQuery.AdapterLuid = GetLuid();
-    segQuery.QuerySegment.SegmentId = i;
-
-    ret = dx::QueryStatistics(&segQuery);
-    if (ret != ErrorCode::Success) {
-      pr_err("Failed to query segment %u info\n", i);
-      return false;
-    }
-
-    const auto& seg = segQuery.QueryResult.SegmentInformation;
-
-    SegmentInfo info;
-    info.segment_id = i;
-    info.segment_type = seg.SegmentProperties.SegmentType;
-    info.system_memory = seg.SegmentProperties.SystemMemory;
-    info.aperture = seg.Aperture;
-    info.commit_limit = seg.CommitLimit;
-
-    segment_infos_.push_back(info);
-
-    pr_info("segment %u: type %u system_memory %u aperture %u "
-            "commit_limit %" PRIu64 "MB bytes_resident %" PRIu64
-            "MB bytes_committed %" PRIu64 "MB\n",
-            i, info.segment_type, info.system_memory ? 1u : 0u,
-            info.aperture ? 1u : 0u, info.commit_limit >> 20,
-            seg.BytesResident >> 20, seg.BytesCommitted >> 20);
-  }
-
-  return true;
-}
-
-bool WDDMDevice::GetSegmentId(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
-                              uint32_t &segment_id) {
-  for (const auto& seg_info : segment_infos_) {
-    if (seg_info.segment_type == segment_type) {
-      segment_id = seg_info.segment_id;
-      return true;
-    }
-  }
-  pr_warn("Failed to get segment id for type %u\n", segment_type);
-  return false;
-}
-
 /*Local heap(dedicated GPU memory) includes visiable heap and invisiable heap.
  *Non local heap refers to shared GPU memory and it is sytem memory.
  */
@@ -167,150 +98,26 @@ ErrorCode WDDMDevice::VramAvail(uint64_t *avail) {
   if (!CpuWait(&page_syncobj_, &value, 1, false))
     return ErrorCode::Unknown;
 
-  // Segment group usage query requires WDDM 3.1+.
-  bool seg_fallback =
-      Platform::instance().WddmVersion() < KMT_DRIVERVERSION_WDDM_3_1;
-  bool segment_info_queried = false;
-  bool have_segment_info = false;
-
-  auto ensure_segment_info = [&]() -> bool {
-    if (segment_info_queried)
-      return have_segment_info;
-    segment_info_queried = true;
-    have_segment_info = QuerySegmentInfo();
-    return have_segment_info;
-  };
-
-  auto query_segment_usage = [this](uint32_t segment_id,
-                                    uint64_t *bytes_resident) -> ErrorCode {
-    D3DKMT_QUERYSTATISTICS seg_stats{};
-    seg_stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-    seg_stats.AdapterLuid = GetLuid();
-    seg_stats.QuerySegment.SegmentId = segment_id;
-
-    ErrorCode seg_ret = dx::QueryStatistics(&seg_stats);
-    if (seg_ret != ErrorCode::Success) {
-      pr_err("Segment %u usage query failed (%d)\n", segment_id,
-             static_cast<int>(seg_ret));
-      *bytes_resident = 0;
-      return seg_ret;
-    }
-
-    *bytes_resident = seg_stats.QueryResult.SegmentInformation.BytesResident;
-    return ErrorCode::Success;
-  };
-
-  auto query_segment_group_usage = [this](uint32_t segment_group,
-                                          const char *name,
-                                          uint64_t *bytes_allocated) -> ErrorCode {
-    D3DKMT_QUERYSTATISTICS sg_stats{};
-    sg_stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT_GROUP_USAGE;
-    sg_stats.AdapterLuid = GetLuid();
-    sg_stats.QuerySegmentGroupUsage.PhysicalAdapterIndex = 0;
-    sg_stats.QuerySegmentGroupUsage.SegmentGroup = segment_group;
-
-    ErrorCode sg_ret = dx::QueryStatistics(&sg_stats);
-    if (sg_ret != ErrorCode::Success) {
-      *bytes_allocated = 0;
-      return sg_ret;
-    }
-
-    const auto &usage = sg_stats.QueryResult.SegmentGroupUsageInformation;
-    *bytes_allocated = usage.AllocatedBytes;
-    pr_info("%s segment group usage: allocated %" PRIu64 "MB, free %" PRIu64
-            "MB, zero %" PRIu64 "MB, modified %" PRIu64 "MB, standby %" PRIu64
-            "MB\n",
-            name, usage.AllocatedBytes >> 20, usage.FreeBytes >> 20,
-            usage.ZeroBytes >> 20, usage.ModifiedBytes >> 20,
-            usage.StandbyBytes >> 20);
-    return ErrorCode::Success;
-  };
-
-  auto resolve_segment_id =
-      [&](D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE segment_type,
-          uint32_t hardcoded_id) -> uint32_t {
-    uint32_t segment_id = hardcoded_id;
-    if (ensure_segment_info() && GetSegmentId(segment_type, segment_id))
-      return segment_id;
-
-    pr_warn("[VramAvail] segment type %u not found, using hardcoded segment %u\n",
-            segment_type, hardcoded_id);
-    return hardcoded_id;
-  };
-
-  auto local_used = [&](uint64_t *used) -> ErrorCode {
-    if (!used)
-      return ErrorCode::InvalidPointer;
-
-    *used = 0;
-    if (!seg_fallback &&
-        query_segment_group_usage(D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL, "Local",
-                                  used) == ErrorCode::Success)
-      return ErrorCode::Success;
-
-    if (!seg_fallback) {
-      pr_warn("Local segment group usage query failed, falling back to segment query\n");
-      seg_fallback = true;
-    }
-
-    uint32_t segment_id =
-        resolve_segment_id(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_MEMORY, 0);
-
-    uint64_t vis = 0;
-    ErrorCode ret = query_segment_usage(segment_id, &vis);
-    if (ret != ErrorCode::Success)
-      return ret;
-    *used = vis;
-
-    if (LocalInvisibleHeapSize()) {
-      segment_id++;
-      uint64_t inv = 0;
-      ret = query_segment_usage(segment_id, &inv);
-      if (ret != ErrorCode::Success)
-        return ret;
-      *used += inv;
-    }
-    return ErrorCode::Success;
-  };
-
-  auto nonlocal_used = [&](uint64_t *used) -> ErrorCode {
-    if (!used)
-      return ErrorCode::InvalidPointer;
-
-    *used = 0;
-    if (!seg_fallback) {
-      if (query_segment_group_usage(D3DKMT_MEMORY_SEGMENT_GROUP_NON_LOCAL,
-                                    "Non-local", used) == ErrorCode::Success)
-        return ErrorCode::Success;
-
-      pr_warn("Non-local segment group usage query failed, falling back to segment query\n");
-    }
-
-    const uint32_t hardcoded_id = LocalInvisibleHeapSize() ? 4 : 3;
-    const uint32_t segment_id =
-        resolve_segment_id(D3DKMT_QUERYSTATISTICS_SEGMENT_TYPE_SYSMEM,
-                           hardcoded_id);
-    return query_segment_usage(segment_id, used);
-  };
-
-  uint64_t usedLocal = 0;
-  ErrorCode ret = local_used(&usedLocal);
+  uint64_t used_local = 0;
+  ErrorCode ret =
+      shared_dev_->QueryVramSegmentUsage(VramSegmentKind::kLocal, &used_local);
   if (ret != ErrorCode::Success)
     return ret;
 
   if (IsDgpu()) {
     const uint64_t total = LocalHeapSize();
-    *avail = usedLocal >= total ? 0 : total - usedLocal;
+    *avail = used_local >= total ? 0 : total - used_local;
     return ErrorCode::Success;
   }
 
-  uint64_t usedNonLocal = 0;
-  ret = nonlocal_used(&usedNonLocal);
+  uint64_t used_non_local = 0;
+  ret = shared_dev_->QueryVramSegmentUsage(VramSegmentKind::kNonLocal,
+                                           &used_non_local);
   if (ret != ErrorCode::Success)
     return ret;
 
   const uint64_t total = LocalHeapSize() + NonLocalHeapSize();
-  const uint64_t used = usedLocal + usedNonLocal;
+  const uint64_t used = used_local + used_non_local;
   *avail = used >= total ? 0 : total - used;
   return ErrorCode::Success;
 }

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -98,26 +98,12 @@ ErrorCode WDDMDevice::VramAvail(uint64_t *avail) {
   if (!CpuWait(&page_syncobj_, &value, 1, false))
     return ErrorCode::Unknown;
 
-  uint64_t used_local = 0;
-  ErrorCode ret =
-      shared_dev_->QueryVramSegmentUsage(VramSegmentKind::kLocal, &used_local);
+  uint64_t used = 0;
+  ErrorCode ret = shared_dev_->QueryVramUsage(&used);
   if (ret != ErrorCode::Success)
     return ret;
 
-  if (IsDgpu()) {
-    const uint64_t total = LocalHeapSize();
-    *avail = used_local >= total ? 0 : total - used_local;
-    return ErrorCode::Success;
-  }
-
-  uint64_t used_non_local = 0;
-  ret = shared_dev_->QueryVramSegmentUsage(VramSegmentKind::kNonLocal,
-                                           &used_non_local);
-  if (ret != ErrorCode::Success)
-    return ret;
-
-  const uint64_t total = LocalHeapSize() + NonLocalHeapSize();
-  const uint64_t used = used_local + used_non_local;
+  const uint64_t total = shared_dev_->VramTotal();
   *avail = used >= total ? 0 : total - used;
   return ErrorCode::Success;
 }


### PR DESCRIPTION
## Motivation

`WDDMDevice` previously owned per-segment WDDM statistics (`QuerySegmentInfo`, `GetSegmentId`, segment-group fallbacks) and duplicated dGPU vs APU total/usage logic. Centralizing this on `Device` keeps librocdxg/amdsmi on a single device facade and moves D3DKMT statistics queries into the shared layer.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
