### PR TITLE
src: promote libhsa-runtime64 symbols for reverse dlsym

### DIFF
--- a/src/hsa.cpp
+++ b/src/hsa.cpp
@@ -1,6 +1,84 @@
 #include <dlfcn.h>
+#include <link.h>
+#include <cstring>
+#include <string>
+
 #include "impl/hsa/hsa.h"
 #include "impl/hsa/hsa_ven_amd_loader.h"
+
+namespace {
+
+constexpr const char *kRequiredHsaRuntimeSymbols[] = {
+    "hsa_signal_load_relaxed",
+    "hsa_signal_wait_relaxed",
+    "hsa_signal_store_screlease",
+    "hsa_system_get_extension_table",
+};
+
+bool hsa_runtime_symbols_available() {
+  for (const char *sym : kRequiredHsaRuntimeSymbols) {
+    if (dlsym(RTLD_DEFAULT, sym) == nullptr)
+      return false;
+  }
+  return true;
+}
+
+constexpr int kHsaRuntimeDlopenFlags = RTLD_NOW | RTLD_GLOBAL;
+
+bool dlopen_promote_global(const char *name, std::string *last_error) {
+  void *handle = dlopen(name, kHsaRuntimeDlopenFlags);
+  if (handle == nullptr) {
+    const char *err = dlerror();
+    pr_debug("dlopen %s failed - %s\n", name, err ? err : "(null)");
+    if (last_error && err)
+      *last_error = std::string(name) + ": " + err;
+    return false;
+  }
+
+  dlclose(handle);
+  return true;
+}
+
+const char *kHsaRuntimeSonames[] = {
+    "libhsa-runtime64.so.1",
+    "libhsa-runtime64.so",
+    nullptr,
+};
+
+struct MappedHsaRuntimeSearch {
+  bool promoted = false;
+  std::string last_error;
+};
+
+int find_mapped_hsa_runtime_cb(struct dl_phdr_info *info, size_t /*size*/,
+                               void *data) {
+  auto *search = static_cast<MappedHsaRuntimeSearch *>(data);
+
+  if (info->dlpi_name == nullptr || info->dlpi_name[0] == '\0')
+    return 0;
+
+  // Match by basename to avoid accidentally hitting unrelated paths.
+  const char *base = std::strrchr(info->dlpi_name, '/');
+  base = base ? base + 1 : info->dlpi_name;
+  if (std::strncmp(base, "libhsa-runtime64.so", 19) != 0)
+    return 0;
+
+  if (dlopen_promote_global(info->dlpi_name, &search->last_error)) {
+    search->promoted = true;
+    return 1;
+  }
+  return 0;
+}
+
+bool dlopen_promote_mapped_hsa_runtime(std::string *last_error) {
+  MappedHsaRuntimeSearch search;
+  dl_iterate_phdr(find_mapped_hsa_runtime_cb, &search);
+  if (!search.promoted && last_error && !search.last_error.empty())
+    *last_error = search.last_error;
+  return search.promoted;
+}
+
+} // namespace
 
 static std::mutex* lock_ = new std::mutex();
 
@@ -25,13 +103,21 @@ do { \
 } while(0);
 
 bool hsakmt_hsa_loader_init() {
-  void *hsa_loader_handle = dlopen("libhsa-runtime64.so", RTLD_NOW | RTLD_GLOBAL);
-  if (hsa_loader_handle == nullptr) {
-    pr_err("dlopen libhsa-runtime64.so failed - %s\n", dlerror());
-    return false;
+  if (hsa_runtime_symbols_available())
+    return true;
+
+  std::string last_error;
+  for (const char *const *name = kHsaRuntimeSonames; *name != nullptr; ++name) {
+    if (dlopen_promote_global(*name, &last_error))
+      return true;
   }
-  dlclose(hsa_loader_handle);
-  return true;
+
+  if (dlopen_promote_mapped_hsa_runtime(&last_error))
+    return true;
+
+  pr_err("failed to promote libhsa-runtime64 symbols (last error: %s)\n",
+         last_error.empty() ? "(none)" : last_error.c_str());
+  return false;
 }
 
 hsa_signal_value_t hsakmt_hsa_signal_load_relaxed(hsa_signal_t signal) {


### PR DESCRIPTION
rocdxg is loaded by libhsa-runtime64 and needs its symbols in the global namespace. Skip work when all required symbols are already bound; otherwise dlopen with RTLD_NOW|RTLD_GLOBAL using .so.1/.so sonames, then the already-mapped library path via dl_iterate_phdr.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
