### PR TITLE
shared: add missing FARPROC typedef for Windows SDK >= 10.0.28000.0

### DIFF
--- a/shared/include/wddm_types.h
+++ b/shared/include/wddm_types.h
@@ -84,6 +84,11 @@ typedef const int16_t *PCWSTR;
 #define DECLARE_HANDLE(name) struct name##__{int unused;}; typedef struct name##__ *name
 #define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
 
+/* FARPROC is used by newer Windows SDK (>=10.0.28000.0) d3dkmthk.h */
+#ifndef FARPROC
+typedef int (*FARPROC)();
+#endif
+
 DECLARE_HANDLE(HWND);
 DECLARE_HANDLE(HDC);
 DECLARE_HANDLE(PALETTEENTRY);


### PR DESCRIPTION
## Motivation

Building librocdxg against Windows SDK 10.0.28000.0 fails to compile because
`d3dkmthk.h` references `FARPROC`, which is not defined in the project's Linux
compatibility headers (`wddm_types.h`). This PR adds the missing typedef so the
build succeeds with newer SDK versions.

## Technical Details

`d3dkmthk.h` (line 965, SDK 10.0.28000.0) uses `FARPROC` inside the
`D3DKMT_PTR` macro. `FARPROC` is a Windows type (`int (*)()`) normally provided
by `windef.h`, but since the project supplies its own compat headers for Linux,
it was missing.

Fix: add `typedef int (*FARPROC)();` (guarded with `#ifndef FARPROC`) to
`shared/include/wddm_types.h`.

## Test Plan

- Clean build with `cmake .. -DWIN_SDK="${win_sdk}/shared" && make` using
  Windows SDK 10.0.28000.0 on Ubuntu 24.04 / WSL2.

## Test Result

Build completes successfully. `librocdxg.so` is generated and installs without
errors.