### PR TITLE
src: report GPU frame buffer size via Device::VramTotal

### DIFF
--- a/src/heap_manager.cpp
+++ b/src/heap_manager.cpp
@@ -145,14 +145,8 @@ bool HeapManager::ReserveLocalHeapSpace() {
     device = get_wddmdev(j+1);
     if (device == nullptr)
       return -1;
-    /*
-     * For APU, use non local memory(shared GPU memory) as GPU memory,
-     * because it has small local memory
-    */
-    if (device->IsDgpu())
-      total_local_size = wsl::Max(device->LocalHeapSize(), total_local_size);
-    else
-      total_local_size = wsl::Max(device->LocalHeapSize() + device->NonLocalHeapSize(), total_local_size);
+
+    total_local_size = wsl::Max(device->SharedDevice()->VramTotal(), total_local_size);
   }
 
   total_local_size = wsl::AlignUp(total_local_size, align) * 4;

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -645,11 +645,7 @@ static HSAKMT_STATUS topology_sysfs_get_mem_props(uint32_t node_id,
 
   props.HeapType = HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE;
 
-  if (device->IsDgpu())
-    props.SizeInBytes = device->LocalHeapSize();
-  else
-    // APU: report both dedicated and shared GPU memory
-    props.SizeInBytes = device->LocalHeapSize() + device->NonLocalHeapSize();
+  props.SizeInBytes = device->SharedDevice()->VramTotal();
 
   props.Width = device->MemoryBusWidth();
   props.MemoryClockMax = device->MaxMemoryClockMhz();


### PR DESCRIPTION
Use shared Device VRAM total for topology mem props instead of duplicating dGPU vs APU heap math.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
