### PR TITLE
hsakmt: wait for paging fence after VA updates

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -644,6 +644,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryVaMap(HsaMemoryObjectHandle Handle,
         return HSAKMT_STATUS_ERROR;
     }
 
+    wsl::thunk::GpuMemory *gpu_mem =
+        reinterpret_cast<wsl::thunk::GpuMemory *>(drmhandle);
+    if (!gpu_mem->GetDevice()->WaitOnPagingFenceFromCpu()) {
+        return HSAKMT_STATUS_ERROR;
+    }
+
     return HSAKMT_STATUS_SUCCESS;
 }
 
@@ -659,6 +665,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryVaUnmap(HsaMemoryObjectHandle Handle,
     int ret = amdgpu_bo_va_op_impl(drmhandle, offset, size, addr, 0,
                               AMDGPU_VA_OP_UNMAP);
     if (ret) {
+        return HSAKMT_STATUS_ERROR;
+    }
+
+    wsl::thunk::GpuMemory *gpu_mem =
+        reinterpret_cast<wsl::thunk::GpuMemory *>(drmhandle);
+    if (!gpu_mem->GetDevice()->WaitOnPagingFenceFromCpu()) {
         return HSAKMT_STATUS_ERROR;
     }
 
@@ -1052,6 +1064,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtUnmapMemoryToGPU(void *MemoryAddress) {
       if (code != ErrorCode::Success)
         return HSAKMT_STATUS_ERROR;
       gpu_mem->Evict();
+      if (!gpu_mem->GetDevice()->WaitOnPagingFenceFromCpu())
+        return HSAKMT_STATUS_ERROR;
 
       return HSAKMT_STATUS_SUCCESS;
     }

--- a/src/wddm/gpu_memory.cpp
+++ b/src/wddm/gpu_memory.cpp
@@ -174,9 +174,10 @@ ErrorCode GpuMemory::UnmapGpuVirtualAddress(const gpusize addr, const gpusize si
 
     code = d3dthunk::MapGpuVirtualAddress(&args);
 
-    if (code == ErrorCode::NotReady)
+    if (code == ErrorCode::NotReady) {
       device_->UpdatePageFence(args.PagingFenceValue);
-    else if (code != ErrorCode::Success)
+      code = ErrorCode::Success;
+    } else if (code != ErrorCode::Success)
       break;
 
     map_addr += block_size;


### PR DESCRIPTION
Ensure VA map/unmap paths wait for DXG paging work to complete before returning, matching the VM update completion semantics expected by ROCr.

## Motivation

This is to adapt https://github.com/ROCm/rocm-systems/pull/6926

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
