### PR TITLE
src: add HSA node id to WDDM adapter index helpers

### DIFF
--- a/src/heap_manager.cpp
+++ b/src/heap_manager.cpp
@@ -87,7 +87,7 @@ bool HeapManager::ReserveSvmSpace(uint64_t &base, uint64_t &size,
 
     int match_cnt = 0;
     for (uint32_t j = 0; j < num_adapters; j++) {
-      device = get_wddmdev(j+1);
+      device = get_wddmdev(wddm_index_to_gpu_node(j));
       uint64_t start = (base == 0) ? (uint64_t)ptr : base;
       uint64_t end = start + ((base == 0) ? sys_va_size : size) + 1;
 
@@ -142,7 +142,7 @@ bool HeapManager::ReserveLocalHeapSpace() {
   size_t num_adapters = get_num_wddmdev();
 
   for (uint32_t j = 0; j < num_adapters; j++) {
-    device = get_wddmdev(j+1);
+    device = get_wddmdev(wddm_index_to_gpu_node(j));
     if (device == nullptr)
       return -1;
 
@@ -166,7 +166,7 @@ bool HeapManager::FreeSvmSpace(uint64_t &base, uint64_t &size) {
   wsl::thunk::WDDMDevice* device;
   size_t num_adapters = get_num_wddmdev();
   for (uint32_t j = 0; j < num_adapters; j++) {
-    device = get_wddmdev(j+1);
+    device = get_wddmdev(wddm_index_to_gpu_node(j));
     if (device == nullptr)
       return -1;
     wsl::thunk::d3dthunk::FreeGpuVirtualAddress(device->GetAdapter(), base, size);
@@ -365,7 +365,7 @@ bool HeapManager::InitHandleApertureSpace() {
 
   while (handle_aperture_start_ < END_NON_CANONICAL_ADDR - 1) {
     for (uint32_t j = 0; j < num_adapters;) {
-      device = get_wddmdev(j+1);
+      device = get_wddmdev(wddm_index_to_gpu_node(j));
       if (device == nullptr)
         return -1;
 

--- a/src/librocdxg.h
+++ b/src/librocdxg.h
@@ -37,6 +37,26 @@
 #include "impl/wddm/device.h"
 #include "shared/include/dxcore_loader.h"
 
+namespace rocdxg {
+
+// HSA KMT node 0 is the CPU node; GPU node ids start here and map to
+// zero-based WDDM adapter indices by subtracting this value.
+constexpr uint32_t kFirstGpuNodeId = 1;
+
+inline constexpr bool is_cpu_hsa_node(uint32_t node_id) {
+  return node_id < kFirstGpuNodeId;
+}
+
+inline constexpr uint32_t gpu_node_to_wddm_index(uint32_t node_id) {
+  return node_id - kFirstGpuNodeId;
+}
+
+inline constexpr uint32_t wddm_index_to_gpu_node(uint32_t wddm_index) {
+  return wddm_index + kFirstGpuNodeId;
+}
+
+} // namespace rocdxg
+
 wsl::thunk::WDDMDevice* get_wddmdev(uint32_t node_id);
 uint32_t get_num_wddmdev();
 wsl::thunk::GpuMemory *get_gpu_mem(void *MemoryAddress);

--- a/src/openclose.cpp
+++ b/src/openclose.cpp
@@ -85,7 +85,8 @@ static HSAKMT_STATUS init_vars_from_env(void) {
     std::string devices(envvar);
     size_t first_num_pos = devices.find_first_of("0123456789");
     if (first_num_pos != std::string::npos)
-      rt.default_node = std::stoi(devices.substr(first_num_pos)) + 1;
+      rt.default_node = rocdxg::wddm_index_to_gpu_node(static_cast<uint32_t>(
+          std::stoi(devices.substr(first_num_pos))));
   }
 
   return HSAKMT_STATUS_SUCCESS;

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -354,13 +354,14 @@ static int get_cpu_cache_info(const char *prefix,
 
 static HSAKMT_STATUS topology_map_node_id(uint32_t node_id,
                                           wsl::thunk::WDDMDevice *&device) {
-  uint32_t idx = node_id;
-  if ((!dxg_topology->wdevices_.size()) || (!node_id) || (node_id >= dxg_topology->num_sysfs_nodes)) {
+  if ((!dxg_topology->wdevices_.size()) ||
+      rocdxg::is_cpu_hsa_node(node_id) ||
+      (node_id >= dxg_topology->num_sysfs_nodes)) {
     device = nullptr;
     return HSAKMT_STATUS_ERROR;
   }
 
-  device = dxg_topology->wdevices_[node_id - 1];
+  device = dxg_topology->wdevices_[rocdxg::gpu_node_to_wddm_index(node_id)];
   return HSAKMT_STATUS_SUCCESS;
 }
 
@@ -515,7 +516,7 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id,
 
   props.MaxEngineClockMhzCCompute = dxg_topology->freq_max_;
 
-  if (node_id == 0) {
+  if (rocdxg::is_cpu_hsa_node(node_id)) {
     /* CPU node */
     props.NumCPUCores = sysconf(_SC_NPROCESSORS_ONLN);
     props.NumMemoryBanks = 1;
@@ -626,7 +627,7 @@ static HSAKMT_STATUS topology_sysfs_get_mem_props(uint32_t node_id,
   HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 
   std::memset(&props, 0, sizeof(props));
-  if (node_id == 0) {
+  if (rocdxg::is_cpu_hsa_node(node_id)) {
     /* CPU node */
     props.HeapType = HSA_HEAPTYPE_SYSTEM;
 
@@ -1483,10 +1484,12 @@ HSAKMT_STATUS validate_nodeid_array(uint32_t **gpu_id_array,
 uint32_t get_num_sysfs_nodes(void) { return dxg_topology->num_sysfs_nodes; }
 
 wsl::thunk::WDDMDevice *get_wddmdev(uint32_t node_id) {
-  if ((!dxg_topology->wdevices_.size()) || (!node_id) || (node_id >= dxg_topology->num_sysfs_nodes))
+  if ((!dxg_topology->wdevices_.size()) ||
+      rocdxg::is_cpu_hsa_node(node_id) ||
+      (node_id >= dxg_topology->num_sysfs_nodes))
     return nullptr;
 
-  return dxg_topology->wdevices_[node_id - 1];
+  return dxg_topology->wdevices_[rocdxg::gpu_node_to_wddm_index(node_id)];
 }
 
 uint32_t get_num_wddmdev() {

--- a/src/wddm/device.cpp
+++ b/src/wddm/device.cpp
@@ -387,7 +387,9 @@ NTSTATUS WDDMCreateDevices(std::vector<WDDMDevice *> &devices)
     auto *chain = sdev->GetLdaChain();
     D3DKMT_HANDLE adapter = chain->AdapterHandle();
 
-    auto device = new WDDMDevice(sdev, adapter, devices.size() + 1);
+    auto device = new WDDMDevice(
+        sdev, adapter,
+        rocdxg::wddm_index_to_gpu_node(static_cast<uint32_t>(devices.size())));
     if (!device)
       continue;
     devices.push_back(device);


### PR DESCRIPTION
Replace implicit node 0 checks and j+1/node_id-1 mappings with rocdxg helpers so CPU vs GPU node numbering stays explicit and consistent.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
