### PR TITLE
wddm/queue: fix AQL->PM4 consumer race on not-yet-published VENDOR_SPECIFIC packets

### DIFF
--- a/src/wddm/queue.cpp
+++ b/src/wddm/queue.cpp
@@ -43,7 +43,9 @@
 #include <cstring>
 #include <cinttypes>
 #include <cstddef>
+#include <atomic>
 
+#include "util/atomic_helpers.h"
 #include "impl/wddm/queue.h"
 #include "impl/registers.h"
 
@@ -61,6 +63,11 @@ extern hsa_status_t hsakmt_hsa_ven_amd_loader_query_host_address(
 
 namespace wsl {
 namespace thunk {
+
+// Format value in a VENDOR_SPECIFIC AQL packet's ven_hdr identifying a PM4
+// indirect-buffer packet (amd_aql_pm4_ib). A VENDOR_SPECIFIC slot is only fully
+// published once ven_hdr holds this; until then the body is still being written.
+static constexpr uint16_t AMD_AQL_FORMAT_PM4_IB = 0x1;
 
 hsa_status_t WDDMQueue::SwsInit(void) {
   if (!device->CreateSyncobj(&syncobj, &sync_addr))
@@ -837,7 +844,6 @@ ComputeQueue::BarrierGenericAqlToPm4(char *cpu, hsa_barrier_and_packet_t *packet
 }
 
 hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char *cpu, amd_aql_pm4_ib *packet) {
-  constexpr uint32_t AMD_AQL_FORMAT_PM4_IB = 0x1;
   assert(packet->ven_hdr == AMD_AQL_FORMAT_PM4_IB);
 
   uint8_t op = (packet->ib_jump_cmd[0] >> PM4_OPCODE_SHIFT) & 0xff;
@@ -915,7 +921,11 @@ hsa_status_t ComputeQueue::SwitchAql2PM4(void) {
 
   uint16_t *packet = (uint16_t *) ((char *)ring +
     (cmdbuf_aql_frame_write_index % ring_size) * 64);
-  uint16_t header = (*packet >> HSA_PACKET_HEADER_TYPE);
+  // Acquire-load the header to pair with the producer's release publication so
+  // the packet body is fully visible before we read it; a plain read races the
+  // producer's burst commit (it bumps the write index before the slot body is
+  // visible) and yields a half-published packet.
+  uint16_t header = (wsl::atomic::Load(packet, std::memory_order_acquire) >> HSA_PACKET_HEADER_TYPE);
   header &= (1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1;
   hsa_kernel_dispatch_packet_t *aql_packet =
     (hsa_kernel_dispatch_packet_t *)packet;
@@ -944,6 +954,13 @@ hsa_status_t ComputeQueue::SwitchAql2PM4(void) {
     BarrierGenericAqlToPm4((char *)ib_start_addr, (hsa_barrier_and_packet_t *)aql_packet, true);
     break;
   case HSA_PACKET_TYPE_VENDOR_SPECIFIC:
+    // A burst commit makes the producer bump the write index before the new
+    // slot's body is fully visible: the header can already read VENDOR_SPECIFIC
+    // (type 0, which passes the INVALID gate) while ven_hdr still holds the slot's
+    // stale value. Treat that as not-yet-published and retry next iteration,
+    // exactly like an INVALID packet.
+    if (((amd_aql_pm4_ib *)aql_packet)->ven_hdr != AMD_AQL_FORMAT_PM4_IB)
+      return HSA_STATUS_SUCCESS;
     VendorSpecificAqlToPm4((char *)ib_start_addr, (amd_aql_pm4_ib *)aql_packet);
     break;
   case HSA_PACKET_TYPE_INVALID:


### PR DESCRIPTION
## Problem

Under sustained workloads that commit large batches of AQL packets in a single write-index advance (e.g. HIP graph replay, which submits a whole captured graph and bumps `write_dispatch_id` by the entire burst at once), `ComputeQueue::AqlToPm4Thread` aborts in `VendorSpecificAqlToPm4` at `assert(packet->ven_hdr == AMD_AQL_FORMAT_PM4_IB)` (`src/wddm/queue.cpp:841`). On `NDEBUG` builds the assert is compiled out and the GPU instead executes a malformed PM4 indirect buffer (silent output corruption).

## Root cause

When the producer commits a burst, `ring_wptr` (`write_dispatch_id`) advances past a slot before that slot's body is fully published. The consumer's `Process` loop admits the slot (`cmdbuf_aql_frame_write_index < ring_wptr->load() && !IsInvalidPacket()`); `IsInvalidPacket` reads the 16-bit header non-atomically and rejects only `HSA_PACKET_TYPE_INVALID`. A recycled slot mid-publication transiently reads header type `VENDOR_SPECIFIC` (`0`, which passes the INVALID gate) while `ven_hdr` still holds the previous occupant's value. The consumer then processes it as a PM4-IB.

Captured with targeted in-shim logging: `dw0 = 0x00030000` (type `0`, `ven_hdr = 0x3`), read coherently via an acquire-`Load`, exactly at `ring_wptr` jumping by the full burst (`wlag` going `1 -> burst`, `rlag = 1`). Observed rate ~7 bad reads / 5.5M vendor packets, every one at the burst boundary. Two distinct defects: (a) no acquire ordering pairing the consumer's slot read with the producer's release publication, and (b) an INVALID-only readiness gate that accepts a not-yet-published `VENDOR_SPECIFIC` slot.

## Fix (`src/wddm/queue.cpp`, +19/-2)

1. Read the slot header in `SwitchAql2PM4` via `wsl::atomic::Load(..., std::memory_order_acquire)` -- the existing `util/atomic_helpers.h`, which already provides the write-combining-aware acquire fence used elsewhere for shared GPU-visible memory (the AQL header reads were bypassing it).
2. Treat a `VENDOR_SPECIFIC` slot whose `ven_hdr != AMD_AQL_FORMAT_PM4_IB` as not-yet-published: `return HSA_STATUS_SUCCESS` and retry on the next loop iteration, identical to the existing INVALID handling.
3. Hoist `AMD_AQL_FORMAT_PM4_IB` to a file-scope constant (DRY).

## Validation

gfx1151 (Radeon 8060S / Ryzen AI Max+ 395), ROCm 7.13 preview, WSL2. Assert-enabled (`-UNDEBUG`) builds running a HIP-graph decode workload: **before** the patch, reproducible abort at `queue.cpp:841`; **after**, zero aborts over full runs (A/B). Dense and non-graph workloads unaffected; `rocminfo` still enumerates the agent.
