### PR TITLE
fix(topology): guard division-by-zero in system properties path

### DIFF
--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -538,15 +538,35 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id,
   props.CComputeIdLo = 0;
   props.FComputeIdLo = 0;
   props.Capability.ui32.ASICRevision = device->AsicRevision();
-  props.Capability.ui32.WatchPointsTotalBits =
-      std::log2(device->WatchPointsNum());
-  props.MaxWavesPerSIMD = device->WavePerCu() / device->SimdPerCu();
+  uint32_t watch_points_num = device->WatchPointsNum();
+  if (watch_points_num == 0) {
+    pr_warn(
+        "WatchPointsNum is 0 for node %u, forcing WatchPointsTotalBits to 0\n",
+        node_id);
+    props.Capability.ui32.WatchPointsTotalBits = 0;
+  } else {
+    props.Capability.ui32.WatchPointsTotalBits = std::log2(watch_points_num);
+  }
+  uint32_t simd_per_cu = device->SimdPerCu();
+  if (simd_per_cu == 0) {
+    pr_warn("SimdPerCu is 0 for node %u, forcing MaxWavesPerSIMD to 0\n",
+            node_id);
+    props.MaxWavesPerSIMD = 0;
+  } else {
+    props.MaxWavesPerSIMD = device->WavePerCu() / simd_per_cu;
+  }
   props.LDSSizeInKB = device->LdsSize() / 1024;
   props.GDSSizeInKB = 0;
   props.WaveFrontSize = device->WavefrontSize();
   props.NumShaderBanks = device->NumShaderEngine();
   props.NumArrays = device->ShaderArrayPerShaderEngine();
-  props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
+  if (props.NumArrays == 0) {
+    pr_warn("NumArrays is 0 for node %u, forcing NumCUPerArray to 0\n",
+            node_id);
+    props.NumCUPerArray = 0;
+  } else {
+    props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
+  }
   props.NumSIMDPerCU = device->SimdPerCu();
   props.MaxSlotsScratchCU = device->MaxScratchSlotsPerCu();
   props.VendorId = 0x1002;


### PR DESCRIPTION
Follow-up to the earlier topology zero-guard work; keep behavior unchanged for valid non-zero device info while preventing undefined behavior on zeros.

Link: https://github.com/ROCm/librocdxg/pull/8

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
