### PR TITLE
amdsmi: load WSL env for interactive bash shells

### DIFF
--- a/amdsmi/DEBIAN/postinst.in
+++ b/amdsmi/DEBIAN/postinst.in
@@ -215,9 +215,33 @@ install_wsl_amdsmi_pth() {
   fi
 }
 
+register_bashrc_env() {
+  local bashrc_file="/etc/bash.bashrc"
+  local begin_marker="# >>> rocdxg-amd-smi-lib >>>"
+  local end_marker="# <<< rocdxg-amd-smi-lib <<<"
+
+  if [ ! -f "$bashrc_file" ]; then
+    return
+  fi
+
+  if grep -Fq "$begin_marker" "$bashrc_file"; then
+    return
+  fi
+
+  cat << 'EOF' >> "$bashrc_file"
+
+# >>> rocdxg-amd-smi-lib >>>
+if [ -f "@CPACK_PACKAGING_INSTALL_PREFIX@/.env.sh" ]; then
+  . "@CPACK_PACKAGING_INSTALL_PREFIX@/.env.sh"
+fi
+# <<< rocdxg-amd-smi-lib <<<
+EOF
+}
+
 
 case "$1" in
   ( configure )
+    register_bashrc_env
     do_install_amdsmi_python_lib
     do_configureLogrotate || exit 0
   ;;

--- a/amdsmi/DEBIAN/prerm.in
+++ b/amdsmi/DEBIAN/prerm.in
@@ -111,6 +111,15 @@ rm_wsl_amdsmi_pth() {
   rm -f "$site_packages/zz-wsl-amdsmi.pth"
 }
 
+rm_bashrc_env() {
+  local bashrc_file="/etc/bash.bashrc"
+  if [ ! -f "$bashrc_file" ]; then
+    return
+  fi
+
+  sed -i '/^# >>> rocdxg-amd-smi-lib >>>$/,/^# <<< rocdxg-amd-smi-lib <<<$/d' "$bashrc_file"
+}
+
 
 case "$1" in
   ( remove | upgrade)
@@ -121,6 +130,8 @@ case "$1" in
     echo "python library removed"
     rm_wsl_amdsmi_pth
     echo "WSL AMD-SMI path registration removed"
+    rm_bashrc_env
+    echo "interactive shell environment registration removed"
     rm_leftovers
     echo "leftovers removed"
     rm_logFolder

--- a/amdsmi/README.md
+++ b/amdsmi/README.md
@@ -54,7 +54,12 @@ sudo dpkg -i rocdxg-amd-smi-lib_<version>_amd64.deb
 
 ### 2. Set up the environment
 
-Installation registers `/etc/profile.d/rocdxg-amd-smi-lib.sh`, which loads `/opt/rocm-wsl/.env.sh` and sets `PYTHONPATH`, `PATH`, and `LD_LIBRARY_PATH`. Apply it in **one** of these ways:
+Installation loads `/opt/rocm-wsl/.env.sh` from:
+
+- `/etc/profile.d/rocdxg-amd-smi-lib.sh` for login shells
+- `/etc/bash.bashrc` for interactive non-login bash shells (for example `docker exec -it <container> bash`)
+
+This sets `PYTHONPATH`, `PATH`, and `LD_LIBRARY_PATH`. Apply it in **one** of these ways:
 
 - **Current shell:** `source /etc/profile.d/rocdxg-amd-smi-lib.sh`
 - **New shell:** open another login or interactive shell; the profile script loads automatically.

--- a/amdsmi/env.sh.in
+++ b/amdsmi/env.sh.in
@@ -1,6 +1,17 @@
-export PYTHONPATH="@AMDSMI_INSTALL_PREFIX@/share/amd_smi${PYTHONPATH:+:$PYTHONPATH}"
-export PATH="@AMDSMI_INSTALL_PREFIX@/bin${PATH:+:$PATH}"
-export LD_LIBRARY_PATH="@AMDSMI_INSTALL_PREFIX@/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+prepend_unique() {
+    # $1: variable name, $2: path to prepend
+    eval "local _current=\"\${$1}\""
+    case ":$_current:" in
+        *":$2:"*) ;;
+        *) eval "export $1=\"$2\${_current:+:$_current}\"" ;;
+    esac
+}
+
+prepend_unique PYTHONPATH "@AMDSMI_INSTALL_PREFIX@/libexec/amdsmi_cli"
+prepend_unique PYTHONPATH "@AMDSMI_INSTALL_PREFIX@/share/amd_smi"
+prepend_unique PATH "@AMDSMI_INSTALL_PREFIX@/bin"
+prepend_unique LD_LIBRARY_PATH "@AMDSMI_INSTALL_PREFIX@/lib"
+unset -f prepend_unique
 
 # If ROCm packages are installed after rocdxg-amd-smi-lib, or if a new pip/venv
 # environment is created later, the .pth file generated during package install


### PR DESCRIPTION
Ensure rocdxg-amd-smi-lib environment setup applies to both login shells and docker exec interactive bash sessions, and make env exports idempotent to avoid duplicate path entries.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
