### PR TITLE
hsakmt: add external semaphore queue signal/wait ABI

### DIFF
--- a/include/hsakmt/hsakmt.h
+++ b/include/hsakmt/hsakmt.h
@@ -1384,9 +1384,7 @@ hsaKmtGetAmdGPUDeviceFd(
 
 /**
   Imports an external semaphore (e.g. from Vulkan) into ROCr's KMD
-  context, returning an opaque handle. The HSA-layer queue signal/wait
-  API that consumes the resulting handle has not landed yet; for now
-  the handle round-trips through hsaKmtDestroyExternalSemaphore only.
+  context, returning an opaque handle.
 */
 
 HSAKMT_STATUS
@@ -1407,6 +1405,31 @@ HSAKMT_STATUS
 HSAKMTAPI
 hsaKmtDestroyExternalSemaphore(
     HSA_EXTERNAL_SEMAPHORE_HANDLE Handle   //IN
+    );
+
+/**
+  Enqueues a GPU-side signal of an imported external semaphore on
+  QueueId, ordered behind prior submissions.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtQueueSignalExternalSemaphore(
+    HSA_QUEUEID                   QueueId,   //IN
+    HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,    //IN
+    HSAuint64                     Value      //IN
+    );
+
+/**
+  Posts a GPU-side wait on an imported external semaphore.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtQueueWaitExternalSemaphore(
+    HSA_QUEUEID                   QueueId,   //IN
+    HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,    //IN
+    HSAuint64                     Value      //IN
     );
 
 #ifdef __cplusplus

--- a/src/extsem.cpp
+++ b/src/extsem.cpp
@@ -17,3 +17,15 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyExternalSemaphore(
   (void)Handle;
   return HSAKMT_STATUS_NOT_SUPPORTED;
 }
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtQueueSignalExternalSemaphore(
+    HSA_QUEUEID QueueId, HSA_EXTERNAL_SEMAPHORE_HANDLE Handle, HSAuint64 Value) {
+  (void)QueueId; (void)Handle; (void)Value;
+  return HSAKMT_STATUS_NOT_SUPPORTED;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtQueueWaitExternalSemaphore(
+    HSA_QUEUEID QueueId, HSA_EXTERNAL_SEMAPHORE_HANDLE Handle, HSAuint64 Value) {
+  (void)QueueId; (void)Handle; (void)Value;
+  return HSAKMT_STATUS_NOT_SUPPORTED;
+}

--- a/src/librocdxg.ver
+++ b/src/librocdxg.ver
@@ -108,6 +108,8 @@ hsaKmtGetAmdGPUDeviceFd;
 hsaKmtMemoryCpuMap;
 hsaKmtImportExternalSemaphore;
 hsaKmtDestroyExternalSemaphore;
+hsaKmtQueueSignalExternalSemaphore;
+hsaKmtQueueWaitExternalSemaphore;
 DxgAbiCheck;
 amdgpu_device_initialize;
 amdgpu_device_deinitialize;


### PR DESCRIPTION
Expose queue signal/wait external semaphore APIs in librocdxg headers and symbol exports.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
