### PR TITLE
wddm/queue: apply acquire Load in IsInvalidPacket and clear ven_hdr on consume

### DIFF
--- a/include/impl/wddm/queue.h
+++ b/include/impl/wddm/queue.h
@@ -54,6 +54,7 @@
 #include "impl/hsa/amd_hsa_queue.h"
 #include "impl/hsa/amd_hsa_signal.h"
 #include "impl/wddm/cmd_util.h"
+#include "util/atomic_helpers.h"
 
 namespace wsl {
 namespace thunk {
@@ -168,7 +169,10 @@ public:
   bool IsInvalidPacket(void) const {
     uint16_t *packet = (uint16_t *)((char *)ring +
                        (cmdbuf_aql_frame_write_index % ring_size) * 64);
-    return ((*packet >> HSA_PACKET_HEADER_TYPE) & ((1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1))
+    // Acquire-load to pair with the producer's release publication, consistent
+    // with SwitchAql2PM4(); a plain read races a burst commit's not-yet-published slot.
+    uint16_t header = wsl::atomic::Load(packet, std::memory_order_acquire);
+    return ((header >> HSA_PACKET_HEADER_TYPE) & ((1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1))
            == HSA_PACKET_TYPE_INVALID;
   }
 

--- a/src/wddm/queue.cpp
+++ b/src/wddm/queue.cpp
@@ -913,6 +913,9 @@ hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char *cpu, amd_aql_pm4_ib *pac
 
   ib_size = i;
   cmdbuf_aql_frame_write_index++;
+  // Clear ven_hdr on consume so a recycled slot can't transiently read a stale
+  // PM4-IB format before the next producer republishes its body.
+  packet->ven_hdr = 0;
   packet->header = HSA_PACKET_TYPE_INVALID;
   return HSA_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Follow-up nits from PR #68:

1. IsInvalidPacket() now reads the slot header via wsl::atomic::Load(..., memory_order_acquire), matching SwitchAql2PM4() so the readiness gate uses the same acquire pairing with the producer's release publication instead of a plain (racy) read.

2. Clear ven_hdr (= 0) when a VENDOR_SPECIFIC slot is consumed, so a recycled slot cannot transiently read a stale AMD_AQL_FORMAT_PM4_IB before the next producer republishes its body.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
